### PR TITLE
feat: allow agents to walk through each other in dense clusters

### DIFF
--- a/docs/06-movement.md
+++ b/docs/06-movement.md
@@ -38,31 +38,38 @@ function astar(start, goal, isBlocked) {
 
 ### Blocked Cells
 
-The following are impassable:
+**For pathfinding (terrain only):** Agents can plan paths through other agents. The pathfinder uses `isBlockedTerrain()` which only checks static obstacles:
 
 | Type | Description |
 |------|-------------|
 | Walls | Destructible barriers |
 | Farms | Crop boosters (also block) |
 | Flags | Faction spawn points |
-| Other agents | Dynamic obstacles (except self) |
+| Water | Water terrain blocks |
+| Trees | Tree blocks |
 | Out of bounds | Grid edges (0 and 61) |
+
+**For movement (agents can pass through each other):** Agents walk freely through cells occupied by other agents on intermediate path steps. Two agents may briefly share a cell during transit. However, an agent cannot **end** its path on an occupied cell:
+- **Intermediate step with agent:** The moving agent passes through (briefly shares the cell).
+- **Final destination with agent:** The agent falls back to an adjacent open cell. If no adjacent cell is free, the path is abandoned.
 
 ### Path Execution
 
 ```javascript
 if (path && pathIdx < path.length) {
   step = path[pathIdx]
-  if (!isBlocked(step.x, step.y, agentId)) {
-    // Move to step
-    cellX = step.x
-    cellY = step.y
-    pathIdx++
-    energy -= moveEnergy  // 0.12
-    // Harvest if on crop
-  } else {
-    // Path blocked, abandon
+  if (isBlockedTerrain(step.x, step.y)) {
+    path = null  // terrain blocked, abandon
+  } else if (hasOtherAgent && isLastStep) {
+    // Fall back to adjacent open cell
+    fallback = findAdjacentOpen(step.x, step.y)
+    if (fallback) moveTo(fallback)
     path = null
+  } else if (hasOtherAgent) {
+    // Wait — keep path, try again next tick
+  } else {
+    moveTo(step)
+    pathIdx++
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emoji-life",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": true,
   "scripts": {
     "build": "esbuild src/main.ts --bundle --outfile=dist/app.js",

--- a/src/domains/simulation/simulation-engine.ts
+++ b/src/domains/simulation/simulation-engine.ts
@@ -529,6 +529,19 @@ export class SimulationEngine {
     }
   }
 
+  /** Find an adjacent cell (4-directional) that is not blocked by terrain or another agent. */
+  private static _findAdjacentOpen(
+    world: World, cx: number, cy: number, selfId: string
+  ): { x: number; y: number } | null {
+    const dirs: [number, number][] = [[1, 0], [-1, 0], [0, 1], [0, -1]];
+    for (const [dx, dy] of dirs) {
+      const nx = cx + dx;
+      const ny = cy + dy;
+      if (!world.grid.isBlocked(nx, ny, selfId)) return { x: nx, y: ny };
+    }
+    return null;
+  }
+
   private static _cleanDead(world: World): void {
     const removedIds: string[] = [];
     world.agents = world.agents.filter((a) => {
@@ -657,27 +670,56 @@ export class SimulationEngine {
       } else {
         const locked = agent.lockMsRemaining > 0 && !agent._underAttack;
         if (!locked) {
-          // Follow path
+          // Follow path — agents walk through each other but cannot land on the same cell
           if (agent.path && agent.pathIdx < agent.path.length) {
             const step = agent.path[agent.pathIdx];
-            if (!world.grid.isBlocked(step.x, step.y, agent.id)) {
-              agent.prevCellX = agent.cellX;
-              agent.prevCellY = agent.cellY;
-              agent.lerpT = 0;
-              world.agentsByCell.delete(key(agent.cellX, agent.cellY));
-              agent.cellX = step.x;
-              agent.cellY = step.y;
-              world.agentsByCell.set(key(agent.cellX, agent.cellY), agent.id);
-              agent.pathIdx++;
-              agent.energy -= TUNE.moveEnergy;
-              agent.drainFullness(TUNE.fullness.moveDecay);
-              agent.hygiene = Math.max(0, agent.hygiene - TUNE.hygiene.moveDecay);
-              // Step-on-poop hygiene penalty
-              if (world.poopBlocks.has(key(agent.cellX, agent.cellY))) {
-                agent.hygiene = Math.max(0, agent.hygiene - TUNE.hygiene.stepOnPoopDecay);
-              }
-            } else {
+            // Terrain blocked → abandon path
+            if (world.grid.isBlockedTerrain(step.x, step.y)) {
               agent.path = null;
+            } else {
+              const cellKey = key(step.x, step.y);
+              const occupant = world.grid.agentsByCell.get(cellKey);
+              const hasOtherAgent = occupant != null && occupant !== agent.id;
+              const isLastStep = agent.pathIdx === agent.path.length - 1;
+
+              let targetX = step.x;
+              let targetY = step.y;
+              let canMove = true;
+
+              if (hasOtherAgent && isLastStep) {
+                // Final destination occupied — fall back to an adjacent open cell
+                const fallback = SimulationEngine._findAdjacentOpen(world, step.x, step.y, agent.id);
+                if (fallback) {
+                  targetX = fallback.x;
+                  targetY = fallback.y;
+                } else {
+                  canMove = false;
+                }
+              }
+              // Intermediate steps: walk through other agents freely
+
+              if (canMove) {
+                agent.prevCellX = agent.cellX;
+                agent.prevCellY = agent.cellY;
+                agent.lerpT = 0;
+                // Conditional delete: only remove if we still own this cell
+                const oldKey = key(agent.cellX, agent.cellY);
+                if (world.agentsByCell.get(oldKey) === agent.id) {
+                  world.agentsByCell.delete(oldKey);
+                }
+                agent.cellX = targetX;
+                agent.cellY = targetY;
+                world.agentsByCell.set(key(agent.cellX, agent.cellY), agent.id);
+                agent.pathIdx++;
+                agent.energy -= TUNE.moveEnergy;
+                agent.drainFullness(TUNE.fullness.moveDecay);
+                agent.hygiene = Math.max(0, agent.hygiene - TUNE.hygiene.moveDecay);
+                if (world.poopBlocks.has(key(agent.cellX, agent.cellY))) {
+                  agent.hygiene = Math.max(0, agent.hygiene - TUNE.hygiene.stepOnPoopDecay);
+                }
+              } else {
+                agent.path = null;
+              }
             }
           } else {
             agent.path = null;

--- a/src/domains/world/grid.ts
+++ b/src/domains/world/grid.ts
@@ -29,6 +29,18 @@ export class Grid {
     return false;
   }
 
+  /** Checks terrain blocking only — agents are ignored. Used for pathfinding so agents can route through each other. */
+  isBlockedTerrain(x: number, y: number): boolean {
+    if (x < 0 || y < 0 || x >= this.size || y >= this.size) return true;
+    const k = key(x, y);
+    if (this.obstacles.has(k)) return true;
+    if (this.farms.has(k)) return true;
+    if (this.flagCells.has(k)) return true;
+    if (this.waterBlocks.has(k)) return true;
+    if (this.treeBlocks.has(k)) return true;
+    return false;
+  }
+
   /** Checks if any interactable block occupies the cell (for spawn no-stacking rule). */
   isCellOccupied(x: number, y: number): boolean {
     if (x < 0 || y < 0 || x >= this.size || y >= this.size) return true;

--- a/src/shared/pathfinding.ts
+++ b/src/shared/pathfinding.ts
@@ -93,7 +93,7 @@ export class Pathfinder {
     const path = Pathfinder.astar(
       { x: a.cellX, y: a.cellY },
       { x: gx, y: gy },
-      (x, y) => world.grid.isBlocked(x, y, a.id)
+      (x, y) => world.grid.isBlockedTerrain(x, y)
     );
     a.path = path;
     a.pathIdx = 0;


### PR DESCRIPTION
## Summary
- Agents in overcrowded clusters were unable to path to water because all adjacent cells were blocked by other agents, causing dehydration deaths
- Pathfinding now uses terrain-only blocking so paths can route through occupied cells
- Agents pass through each other on intermediate steps; final destination falls back to an adjacent open cell if occupied

## Test plan
- [ ] Spawn a large population and observe that agents in dense clusters can still reach water
- [ ] Verify agents don't permanently stack on the same cell (fallback logic works)
- [ ] Confirm agents still respect terrain blocking (obstacles, water, trees, farms, flags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)