### PR TITLE
feat: add baby stage for newborns

### DIFF
--- a/docs/10-reproduction.md
+++ b/docs/10-reproduction.md
@@ -95,6 +95,32 @@ function completeReproduction(world, agent, partner) {
 | Health | 80 |
 | Level | 1 |
 | Attack | 8 (base) |
+| Fullness | Transferred from parents (see below) |
+
+### Fullness Transfer
+
+Fullness is not materialized from nothing — it is transferred from the parents:
+
+```
+p1Donate = random(15, 25), capped at parent1.fullness
+p2Donate = random(15, 25), capped at parent2.fullness
+child.fullness = min(100, p1Donate + p2Donate)
+parent1.fullness -= p1Donate
+parent2.fullness -= p2Donate
+```
+
+### Baby Stage
+
+Newborns begin in a baby stage lasting a random duration (~60s):
+
+```
+babyMs = random(50000, 70000)  // ms
+```
+
+While `babyMsRemaining > 0`:
+- The agent displays the 👶 emoji
+- No actions can be taken (only movement is allowed)
+- The timer decrements each simulation tick until it reaches 0
 
 ### Inherited Traits
 
@@ -142,8 +168,10 @@ if (childFaction):
 |-----------|---------------------|
 | Upfront reserve | 4 |
 | Action duration | ~2.2 (avg) |
-| Completion | 12 |
-| **Total** | **18.2** |
+| Completion (energy) | 12 |
+| Completion (fullness) | 15–25 |
+| **Total energy** | **~18.2** |
+| **Total fullness** | **~15–25** |
 
 ### Energy After Reproduction
 

--- a/src/domains/action/action-processor.ts
+++ b/src/domains/action/action-processor.ts
@@ -244,8 +244,17 @@ export class ActionProcessor {
         if (free) {
           agent.drainEnergy(12);
           targ.drainEnergy(12);
+          // Transfer fullness from parents to child
+          const p1Range = TUNE.baby.fullnessPerParent;
+          const p2Range = TUNE.baby.fullnessPerParent;
+          const p1Donate = Math.min(agent.fullness, p1Range[0] + Math.random() * (p1Range[1] - p1Range[0]));
+          const p2Donate = Math.min(targ.fullness, p2Range[0] + Math.random() * (p2Range[1] - p2Range[0]));
+          agent.drainFullness(p1Donate);
+          targ.drainFullness(p2Donate);
+          const childFullness = Math.min(TUNE.fullness.max, p1Donate + p2Donate);
+          const babyMs = TUNE.baby.durationRange[0] + Math.random() * (TUNE.baby.durationRange[1] - TUNE.baby.durationRange[0]);
           const [x, y] = free;
-          const child = AgentFactory.createChild(world, agent, targ, x, y);
+          const child = AgentFactory.createChild(world, agent, targ, x, y, childFullness, babyMs);
           const pa = agent.factionId || null;
           const pb = targ.factionId || null;
           let chosen: string | null = null;

--- a/src/domains/action/interaction-engine.ts
+++ b/src/domains/action/interaction-engine.ts
@@ -28,6 +28,16 @@ export class InteractionEngine {
    *    e. Share/Heal/Talk
    */
   static consider(world: World, agent: Agent): void {
+    // Babies can only eat/drink from inventory — no harvesting or other actions
+    if (agent.babyMsRemaining > 0) {
+      if (agent.fullness < TUNE.fullness.seekThreshold && agent.inventory.food > 0) {
+        ActionFactory.tryStart(agent, 'eat');
+      } else if (agent.hygiene < TUNE.hygiene.seekThreshold && agent.inventory.water > 0) {
+        ActionFactory.tryStart(agent, 'drink');
+      }
+      return;
+    }
+
     // 1. Mandatory sleep
     if (agent.energy < TUNE.sleep.mandatoryThreshold) {
       if (InteractionEngine._trySleep(agent)) return;

--- a/src/domains/agent/agent-factory.ts
+++ b/src/domains/agent/agent-factory.ts
@@ -24,7 +24,9 @@ export class AgentFactory {
     parent1: Agent,
     parent2: Agent,
     x: number,
-    y: number
+    y: number,
+    fullness: number,
+    babyMsRemaining: number
   ): Agent {
     const child = new Agent({
       id: uuid(),
@@ -33,12 +35,13 @@ export class AgentFactory {
       cellY: y,
       energy: 60,
       health: 80,
-      fullness: 100,
+      fullness,
       hygiene: 80,
       social: 50,
       inspiration: 50,
       aggression: clamp((parent1.aggression + parent2.aggression) / 2, 0, 1),
       cooperation: clamp((parent1.cooperation + parent2.cooperation) / 2, 0, 1),
+      babyMsRemaining,
     });
     world.agents.push(child);
     world.agentsById.set(child.id, child);

--- a/src/domains/agent/agent.ts
+++ b/src/domains/agent/agent.ts
@@ -41,6 +41,9 @@ export class Agent {
   poopTimerMs: number;
   diseased: boolean;
 
+  // Baby stage
+  babyMsRemaining: number;
+
   constructor(opts: {
     id: string;
     name: string;
@@ -71,6 +74,7 @@ export class Agent {
     inventory?: IInventory;
     poopTimerMs?: number;
     diseased?: boolean;
+    babyMsRemaining?: number;
   }) {
     this.id = opts.id;
     this.name = opts.name;
@@ -107,6 +111,7 @@ export class Agent {
     this.inventory = opts.inventory ?? { food: 0, water: 0, wood: 0 };
     this.poopTimerMs = opts.poopTimerMs ?? 0;
     this.diseased = opts.diseased ?? false;
+    this.babyMsRemaining = opts.babyMsRemaining ?? 0;
   }
 
   takeDamage(amount: number): void {

--- a/src/domains/persistence/persistence-manager.ts
+++ b/src/domains/persistence/persistence-manager.ts
@@ -53,6 +53,7 @@ export class PersistenceManager {
       inventory: a.inventory,
       poopTimerMs: a.poopTimerMs,
       diseased: a.diseased,
+      babyMsRemaining: a.babyMsRemaining,
     }));
     return {
       meta: { version: VERSION, savedAt: Date.now() },
@@ -269,6 +270,7 @@ export class PersistenceManager {
         inventory: a.inventory ?? { food: 0, water: 0, wood: 0 },
         poopTimerMs: a.poopTimerMs ?? 0,
         diseased: a.diseased ?? false,
+        babyMsRemaining: a.babyMsRemaining ?? 0,
       });
       world.agents.push(agent);
       world.agentsById.set(agent.id, agent);

--- a/src/domains/rendering/renderer.ts
+++ b/src/domains/rendering/renderer.ts
@@ -1,4 +1,4 @@
-import { CELL, GRID, COLORS, AGENT_EMOJIS, WORLD_EMOJIS, FOOD_EMOJIS, TUNE } from '../../shared/constants';
+import { CELL, GRID, COLORS, AGENT_EMOJIS, IDLE_EMOJIS, WORLD_EMOJIS, FOOD_EMOJIS, TUNE } from '../../shared/constants';
 import { getIdleEmoji } from '../../shared/utils';
 import type { World } from '../world';
 import type { Agent } from '../agent';
@@ -164,7 +164,12 @@ export class Renderer {
         ? world.factions.get(agent.factionId)?.color || '#fff'
         : '#6b7280';
       const actionType = agent.action?.type;
-      const emoji = AGENT_EMOJIS[actionType as string] || getIdleEmoji(agent);
+      let emoji: string;
+      if (agent.babyMsRemaining > 0 && (actionType === 'eat' || actionType === 'drink')) {
+        emoji = IDLE_EMOJIS.babyEating;
+      } else {
+        emoji = AGENT_EMOJIS[actionType as string] || getIdleEmoji(agent);
+      }
 
       this._drawAgentEmoji(ctx, x, y, CELL / 2 - 3, col, emoji);
 

--- a/src/domains/simulation/simulation-engine.ts
+++ b/src/domains/simulation/simulation-engine.ts
@@ -644,6 +644,7 @@ export class SimulationEngine {
       // Poop timer decay
       if (agent.poopTimerMs > 0) agent.poopTimerMs -= BASE_TICK_MS;
       agent.lockMsRemaining = Math.max(0, (agent.lockMsRemaining || 0) - BASE_TICK_MS);
+      if (agent.babyMsRemaining > 0) agent.babyMsRemaining = Math.max(0, agent.babyMsRemaining - BASE_TICK_MS);
 
       // Don't cancel sleep, attack, harvest, eat, drink, or short utility actions on low energy
       if (agent.energy < TUNE.energyLowThreshold) {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -47,6 +47,10 @@ export const TUNE = {
   levelCap: 20,
   maxCrops: 100,
   reproduction: { relationshipThreshold: 0.4, relationshipEnergy: 90 },
+  baby: {
+    durationRange: [50000, 70000] as [number, number],
+    fullnessPerParent: [15, 25] as [number, number],
+  },
   pathBudgetPerTick: 30,
   fullness: {
     max: 100,
@@ -252,6 +256,8 @@ export const AGENT_EMOJIS: Record<string, string> = {
 };
 
 export const IDLE_EMOJIS = {
+  baby: '👶',
+  babyEating: '👼',
   lowEnergy: '🤤',
   lowHealth: '🤕',
   lowFullness: '😩',

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -62,7 +62,8 @@ export class RingLog {
   }
 }
 
-export const getIdleEmoji = (a: { energy: number; health: number; fullness: number; diseased?: boolean }): string => {
+export const getIdleEmoji = (a: { energy: number; health: number; fullness: number; diseased?: boolean; babyMsRemaining?: number }): string => {
+  if (a.babyMsRemaining && a.babyMsRemaining > 0) return IDLE_EMOJIS.baby;
   if (a.diseased) return IDLE_EMOJIS.diseased;
   if (a.fullness <= 20) return IDLE_EMOJIS.lowFullness;
   if (a.energy <= 20) return IDLE_EMOJIS.lowEnergy;


### PR DESCRIPTION
## Summary

- Newborns enter a baby stage lasting ~60s (`babyMsRemaining` timer)
- During baby stage: agent displays 👶 emoji, can only eat/drink from inventory, no other actions
- Fullness is transferred from parents (15–25 each) instead of spawning at 100, adding real resource cost to reproduction
- Baby stage is persisted in save/load

## Test plan

- [ ] Reproduce two agents and confirm child spawns with 👶 emoji
- [ ] Confirm child cannot harvest, attack, or take other actions while baby timer is active
- [ ] Confirm child's fullness reflects parent donation (not full 100)
- [ ] Confirm parent fullness decreases after reproduction
- [ ] Confirm baby eventually grows up (emoji changes after ~60s)
- [ ] Save and reload — confirm `babyMsRemaining` is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)