### PR TITLE
feat: baby stage + fix stationary cell overlap (v3.2.2)

### DIFF
--- a/docs/06-movement.md
+++ b/docs/06-movement.md
@@ -49,9 +49,10 @@ function astar(start, goal, isBlocked) {
 | Trees | Tree blocks |
 | Out of bounds | Grid edges (0 and 61) |
 
-**For movement (agents can pass through each other):** Agents walk freely through cells occupied by other agents on intermediate path steps. Two agents may briefly share a cell during transit. However, an agent cannot **end** its path on an occupied cell:
-- **Intermediate step with agent:** The moving agent passes through (briefly shares the cell).
+**For movement (agents can pass through each other):** Moving agents can freely pass through cells occupied by other agents (both stationary and moving). However, agents can **never occupy the same cell when stationary**:
+- **Intermediate step with agent:** The moving agent passes through without claiming the cell in the occupancy map. The existing occupant's registration is preserved.
 - **Final destination with agent:** The agent falls back to an adjacent open cell. If no adjacent cell is free, the path is abandoned.
+- **Stationary safety net:** When an agent finishes its path on an occupied cell (e.g., path was abandoned mid-transit), it is automatically relocated to an adjacent open cell.
 
 ### Path Execution
 
@@ -64,13 +65,19 @@ if (path && pathIdx < path.length) {
     // Fall back to adjacent open cell
     fallback = findAdjacentOpen(step.x, step.y)
     if (fallback) moveTo(fallback)
-    path = null
-  } else if (hasOtherAgent) {
-    // Wait — keep path, try again next tick
+    else path = null
   } else {
+    // Move freely — if cell is occupied, pass through without claiming it
     moveTo(step)
+    if (!hasOtherAgent) registerInCell(step)
     pathIdx++
   }
+}
+
+// After movement: ensure stationary agents own a unique cell
+if (!path) {
+  if (cellOccupiedByOther) relocateToAdjacentOpen()
+  else registerInCell(currentPos)
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emoji-life",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": true,
   "scripts": {
     "build": "esbuild src/main.ts --bundle --outfile=dist/app.js",

--- a/src/domains/simulation/simulation-engine.ts
+++ b/src/domains/simulation/simulation-engine.ts
@@ -710,7 +710,12 @@ export class SimulationEngine {
                 }
                 agent.cellX = targetX;
                 agent.cellY = targetY;
-                world.agentsByCell.set(key(agent.cellX, agent.cellY), agent.id);
+                // Only register in cell map if not passing through another agent
+                const newKey = key(agent.cellX, agent.cellY);
+                const newOccupant = world.agentsByCell.get(newKey);
+                if (!newOccupant || newOccupant === agent.id) {
+                  world.agentsByCell.set(newKey, agent.id);
+                }
                 agent.pathIdx++;
                 agent.energy -= TUNE.moveEnergy;
                 agent.drainFullness(TUNE.fullness.moveDecay);
@@ -724,6 +729,27 @@ export class SimulationEngine {
             }
           } else {
             agent.path = null;
+          }
+
+          // Ensure stationary agents are registered on a unique cell
+          // (handles agents who passed through an occupied cell and then stopped)
+          if (!agent.path || agent.pathIdx >= agent.path.length) {
+            const ck = key(agent.cellX, agent.cellY);
+            const occupant = world.agentsByCell.get(ck);
+            if (occupant && occupant !== agent.id) {
+              const open = SimulationEngine._findAdjacentOpen(world, agent.cellX, agent.cellY, agent.id);
+              if (open) {
+                agent.prevCellX = agent.cellX;
+                agent.prevCellY = agent.cellY;
+                agent.lerpT = 0;
+                agent.cellX = open.x;
+                agent.cellY = open.y;
+                world.agentsByCell.set(key(open.x, open.y), agent.id);
+              }
+              // If no open cell, agent stays unregistered temporarily — next tick will retry
+            } else if (!occupant) {
+              world.agentsByCell.set(ck, agent.id);
+            }
           }
 
           // Idle decision — delegate to InteractionEngine for priority hierarchy


### PR DESCRIPTION
## Summary
- **Baby stage for newborns:** Newborn agents enter a baby stage (~60s) where they display 👶, can only eat/drink from inventory, and cannot take other actions. Fullness is transferred from parents rather than spawned at 100.
- **Fix stationary cell overlap:** Moving agents can now pass through occupied cells without corrupting the occupancy map. A safety net ensures agents are never stationary on the same cell — they relocate to an adjacent open cell if needed.
- Bumps version to 3.2.2.

## Test plan
- [ ] Verify newborns show 👶 emoji and transition to normal after ~60s
- [ ] Verify babies can only eat/drink, not harvest/attack/etc.
- [ ] Verify parent fullness decreases after reproduction
- [ ] Observe crowded areas: agents should pass through each other smoothly but never stack when idle
- [ ] Save/load a game with babies present — baby timer should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)