### PR TITLE
feat: gameplay improvements and bug fixes (v3.2.3)

### DIFF
--- a/index.html
+++ b/index.html
@@ -951,8 +951,10 @@
           <input id="rngAgents" type="range" min="20" max="300" step="1" value="20"/>
           <div class="param-row"><span class="param-label">SIMULATION SPEED</span><span class="param-value" id="lblSpeed">100%</span></div>
           <input id="rngSpeed" type="range" min="5" max="300" step="1" value="100"/>
-          <div class="param-row"><span class="param-label">CROP SPAWN MULTIPLIER</span><span class="param-value" id="lblSpawn">1.0&times;</span></div>
-          <input id="rngSpawn" type="range" min="0.0" max="20.0" step="0.1" value="1"/>
+          <div class="param-row"><span class="param-label">CLOUD SPAWN RATE</span><span class="param-value" id="lblCloudRate">1.0&times;</span></div>
+          <input id="rngCloudRate" type="range" min="0" max="10.0" step="0.1" value="1"/>
+          <div class="param-row"><span class="param-label">WORLD SIZE</span><span class="param-value" id="lblWorldSize">62&times;62</span></div>
+          <input id="rngWorldSize" type="range" min="20" max="120" step="2" value="62"/>
         </div>
       </div>
     </div>
@@ -979,6 +981,9 @@
           </button>
           <button id="btnEraseObstacles" class="tool-btn">
             <span class="tool-icon">&#128221;</span> Erase Structures <span class="tool-badge">ACTIVE</span>
+          </button>
+          <button id="btnReplenish" class="tool-btn">
+            <span class="tool-icon">&#10024;</span> Replenish Agent <span class="tool-badge">ACTIVE</span>
           </button>
           <div style="margin-top:12px">
             <label class="toggle-row"><input type="checkbox" id="cbPauseOnBlur"/> Pause when unfocused</label>
@@ -1102,7 +1107,8 @@
     <div style="display: none">
       <input id="numAgents" type="number" min="20" max="300" step="1" value="20" />
       <input id="numSpeed" type="number" min="5" max="300" step="1" value="50" />
-      <input id="numSpawn" type="number" min="0.1" max="5" step="0.1" value="1" />
+      <input id="numCloudRate" type="number" min="0" max="10" step="0.1" value="1" />
+      <input id="numWorldSize" type="number" min="20" max="120" step="2" value="62" />
       <input id="fileLoad" type="file" accept="application/json" />
     </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emoji-life",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "private": true,
   "scripts": {
     "build": "esbuild src/main.ts --bundle --outfile=dist/app.js",

--- a/src/domains/action/action-processor.ts
+++ b/src/domains/action/action-processor.ts
@@ -288,13 +288,24 @@ export class ActionProcessor {
   private static _harvestFood(world: World, agent: Agent, tp: { x: number; y: number }): void {
     const k = key(tp.x, tp.y);
     const block = world.foodBlocks.get(k);
-    if (!block || block.units <= 0) return;
-    block.units--;
-    agent.addToInventory('food', 1);
-    agent.addXp(TUNE.xp.perHarvest);
-    log(world, 'harvest', `${agent.name} harvested food`, agent.id, { x: tp.x, y: tp.y });
-    if (block.units <= 0) world.foodBlocks.delete(k);
-    ActionProcessor._checkLevelUp(world, agent);
+    if (block && block.units > 0) {
+      block.units--;
+      agent.addToInventory('food', 1);
+      agent.addXp(TUNE.xp.perHarvest);
+      log(world, 'harvest', `${agent.name} harvested food`, agent.id, { x: tp.x, y: tp.y });
+      if (block.units <= 0) world.foodBlocks.delete(k);
+      ActionProcessor._checkLevelUp(world, agent);
+      return;
+    }
+    // Fallback: harvest seedling as low-quality food
+    const seedling = world.seedlings.get(k);
+    if (seedling) {
+      world.seedlings.delete(k);
+      agent.addToInventory('food', 1);
+      agent.addXp(TUNE.xp.perHarvest);
+      log(world, 'harvest', `${agent.name} harvested seedling`, agent.id, { x: tp.x, y: tp.y });
+      ActionProcessor._checkLevelUp(world, agent);
+    }
   }
 
   private static _harvestWater(world: World, agent: Agent, tp: { x: number; y: number }): void {
@@ -337,7 +348,9 @@ export class ActionProcessor {
     if (roll < TUNE.tree.seedlingChanceOnHarvest) {
       SimulationEngine.trySpawnSeedling(world, tree.x, tree.y);
     } else if (roll < TUNE.tree.seedlingChanceOnHarvest + TUNE.tree.foodChanceOnHarvest) {
-      SimulationEngine.trySpawnFoodNearTree(world, tree.x, tree.y);
+      // Food only spawns if poop nearby
+      const hasPoop = SimulationEngine.hasPoopNearby(world, tree.x, tree.y, TUNE.tree.foodRequiresPoopRadius);
+      if (hasPoop) SimulationEngine.trySpawnFoodNearTree(world, tree.x, tree.y);
     }
 
     if (tree.units <= 0) world.treeBlocks.delete(k);

--- a/src/domains/agent/agent.ts
+++ b/src/domains/agent/agent.ts
@@ -1,5 +1,5 @@
 import type { IActionState, IInventory, IPosition } from '../../shared/types';
-import { TUNE } from '../../shared/constants';
+import { TUNE, BASE_TICK_MS } from '../../shared/constants';
 import { RelationshipMap } from './relationships';
 
 export class Agent {
@@ -44,6 +44,9 @@ export class Agent {
   // Baby stage
   babyMsRemaining: number;
 
+  // Aging
+  maxAgeTicks: number;
+
   constructor(opts: {
     id: string;
     name: string;
@@ -75,6 +78,7 @@ export class Agent {
     poopTimerMs?: number;
     diseased?: boolean;
     babyMsRemaining?: number;
+    maxAgeTicks?: number;
   }) {
     this.id = opts.id;
     this.name = opts.name;
@@ -112,6 +116,13 @@ export class Agent {
     this.poopTimerMs = opts.poopTimerMs ?? 0;
     this.diseased = opts.diseased ?? false;
     this.babyMsRemaining = opts.babyMsRemaining ?? 0;
+
+    if (opts.maxAgeTicks != null) {
+      this.maxAgeTicks = opts.maxAgeTicks;
+    } else {
+      const maxAgeMs = TUNE.agent.maxAgeRange[0] + Math.random() * (TUNE.agent.maxAgeRange[1] - TUNE.agent.maxAgeRange[0]);
+      this.maxAgeTicks = Math.floor(maxAgeMs / BASE_TICK_MS);
+    }
   }
 
   takeDamage(amount: number): void {

--- a/src/domains/persistence/persistence-manager.ts
+++ b/src/domains/persistence/persistence-manager.ts
@@ -54,6 +54,7 @@ export class PersistenceManager {
       poopTimerMs: a.poopTimerMs,
       diseased: a.diseased,
       babyMsRemaining: a.babyMsRemaining,
+      maxAgeTicks: a.maxAgeTicks,
     }));
     return {
       meta: { version: VERSION, savedAt: Date.now() },
@@ -61,7 +62,7 @@ export class PersistenceManager {
       state: {
         tick: world.tick,
         speedPct: world.speedPct,
-        spawnMult: world.spawnMult,
+        cloudSpawnRate: world.cloudSpawnRate,
         drawGrid: world.drawGrid,
         pauseOnBlur: world.pauseOnBlur,
         totalBirths: world.totalBirths,
@@ -141,7 +142,7 @@ export class PersistenceManager {
     world.factions.clear();
     world.tick = d.state?.tick ?? 0;
     world.speedPct = d.state?.speedPct ?? world.speedPct;
-    world.spawnMult = d.state?.spawnMult ?? world.spawnMult;
+    world.cloudSpawnRate = d.state?.cloudSpawnRate ?? world.cloudSpawnRate;
     world.drawGrid = d.state?.drawGrid ?? true;
     world.pauseOnBlur = d.state?.pauseOnBlur ?? false;
     world.totalBirths = d.state?.totalBirths ?? 0;
@@ -198,6 +199,8 @@ export class PersistenceManager {
         id: tb.id, x: tb.x, y: tb.y,
         emoji: tb.emoji, units: tb.units ?? 3,
         maxUnits: tb.maxUnits ?? 3,
+        ageTotalMs: tb.ageTotalMs ?? 0,
+        maxAgeMs: tb.maxAgeMs ?? rndi(TUNE.tree.maxAgeRange[0], TUNE.tree.maxAgeRange[1]),
       });
     }
     // Restore seedlings
@@ -271,6 +274,7 @@ export class PersistenceManager {
         poopTimerMs: a.poopTimerMs ?? 0,
         diseased: a.diseased ?? false,
         babyMsRemaining: a.babyMsRemaining ?? 0,
+        maxAgeTicks: a.maxAgeTicks,
       });
       world.agents.push(agent);
       world.agentsById.set(agent.id, agent);
@@ -294,8 +298,8 @@ export class PersistenceManager {
     if (dom.ranges.rngSpeed) dom.ranges.rngSpeed.value = String(world.speedPct);
     if (dom.nums.numSpeed) dom.nums.numSpeed.value = String(world.speedPct);
     if (dom.labels.lblSpeed) dom.labels.lblSpeed.textContent = `${world.speedPct}%`;
-    if (dom.ranges.rngSpawn) dom.ranges.rngSpawn.value = String(world.spawnMult);
-    if (dom.nums.numSpawn) dom.nums.numSpawn.value = String(world.spawnMult);
-    if (dom.labels.lblSpawn) dom.labels.lblSpawn.textContent = world.spawnMult.toFixed(1) + '\u00d7';
+    if (dom.ranges.rngCloudRate) dom.ranges.rngCloudRate.value = String(world.cloudSpawnRate);
+    if (dom.nums.numCloudRate) dom.nums.numCloudRate.value = String(world.cloudSpawnRate);
+    if (dom.labels.lblCloudRate) dom.labels.lblCloudRate.textContent = world.cloudSpawnRate.toFixed(1) + '\u00d7';
   }
 }

--- a/src/domains/rendering/renderer.ts
+++ b/src/domains/rendering/renderer.ts
@@ -21,6 +21,7 @@ export class Renderer {
     this._drawWaterBlocks(ctx, world);
     this._drawTreeBlocks(ctx, world);
     this._drawSeedlings(ctx, world);
+    this._drawEggs(ctx, world);
     this._drawPoopBlocks(ctx, world);
     this._drawFoodBlocks(ctx, world);
     this._drawLootBags(ctx, world);
@@ -92,6 +93,12 @@ export class Renderer {
   private _drawSeedlings(ctx: CanvasRenderingContext2D, world: World): void {
     for (const s of world.seedlings.values()) {
       this._drawCellEmoji(ctx, s.x, s.y, WORLD_EMOJIS.seedling);
+    }
+  }
+
+  private _drawEggs(ctx: CanvasRenderingContext2D, world: World): void {
+    for (const egg of world.eggs.values()) {
+      this._drawCellEmoji(ctx, egg.x, egg.y, WORLD_EMOJIS.egg);
     }
   }
 
@@ -172,11 +179,6 @@ export class Renderer {
       }
 
       this._drawAgentEmoji(ctx, x, y, CELL / 2 - 3, col, emoji);
-
-      // HP bar
-      const hpw = Math.max(0, Math.floor((CELL - 6) * (agent.health / agent.maxHealth)));
-      ctx.fillStyle = COLORS.hp;
-      ctx.fillRect(x + 3, y - 4, hpw, 2);
 
       // Collect attack lines
       if (agent.action?.type === 'attack' && agent.action.payload?.targetId) {

--- a/src/domains/simulation/simulation-engine.ts
+++ b/src/domains/simulation/simulation-engine.ts
@@ -8,6 +8,7 @@ import { PoopBlockManager } from '../world/poop-block-manager';
 import type { World } from '../world';
 import type { Agent } from '../agent';
 import { ActionFactory, ActionProcessor, InteractionEngine } from '../action';
+import { AgentFactory } from '../agent/agent-factory';
 import { FactionManager } from '../faction';
 import { RoamingStrategy } from './roaming';
 
@@ -24,7 +25,6 @@ export class SimulationEngine {
   }
 
   static addCrop(world: World, x: number, y: number): boolean {
-    if (world.foodBlocks.size >= TUNE.maxCrops) return false;
     const k = key(x, y);
     if (world.grid.isCellOccupied(x, y)) return false;
     const units = rndi(TUNE.foodBlock.lqUnits[0], TUNE.foodBlock.lqUnits[1]);
@@ -52,10 +52,8 @@ export class SimulationEngine {
   }
 
   private static _maybeSpawnCrops(world: World): void {
-    if (world.foodBlocks.size >= TUNE.maxCrops) return;
     const toDelete: string[] = [];
     for (const [fk, fm] of world.farms) {
-      if (world.foodBlocks.size >= TUNE.maxCrops) break;
       fm.spawnTimerMs -= BASE_TICK_MS;
       if (fm.spawnTimerMs > 0) continue;
 
@@ -174,10 +172,12 @@ export class SimulationEngine {
       const y = rndi(0, GRID - 1);
       if (world.grid.isCellOccupied(x, y)) continue;
       const units = rndi(TUNE.tree.unitRange[0], TUNE.tree.unitRange[1]);
+      const maxAgeMs = rndi(TUNE.tree.maxAgeRange[0], TUNE.tree.maxAgeRange[1]);
       world.treeBlocks.set(key(x, y), {
         id: uuid(), x, y,
         emoji: SimulationEngine._randomTreeEmoji(),
         units, maxUnits: units,
+        ageTotalMs: 0, maxAgeMs,
       });
       log(world, 'spawn', `tree @${x},${y}`, null, { x, y });
       return true;
@@ -194,6 +194,16 @@ export class SimulationEngine {
   // ── Seedling / tree passive spawns ──
 
   static trySpawnSeedling(world: World, originX: number, originY: number): boolean {
+    // Require water within range to spawn seedling
+    let nearWater = false;
+    for (const wb of world.waterBlocks.values()) {
+      if (manhattan(originX, originY, wb.x, wb.y) <= TUNE.tree.waterRequiredForSeedling) {
+        nearWater = true;
+        break;
+      }
+    }
+    if (!nearWater) return false;
+
     const r = TUNE.tree.seedlingRadius;
     for (let attempt = 0; attempt < 20; attempt++) {
       const x = originX + rndi(-r, r);
@@ -241,25 +251,37 @@ export class SimulationEngine {
       const s = world.seedlings.get(k)!;
       world.seedlings.delete(k);
       const units = rndi(TUNE.tree.unitRange[0], TUNE.tree.unitRange[1]);
+      const maxAgeMs = rndi(TUNE.tree.maxAgeRange[0], TUNE.tree.maxAgeRange[1]);
       world.treeBlocks.set(k, {
         id: uuid(), x: s.x, y: s.y,
         emoji: SimulationEngine._randomTreeEmoji(),
         units, maxUnits: units,
+        ageTotalMs: 0, maxAgeMs,
       });
       log(world, 'spawn', `seedling grew into tree @${s.x},${s.y}`, null, { x: s.x, y: s.y });
     }
   }
 
+  static hasPoopNearby(world: World, x: number, y: number, radius: number): boolean {
+    for (const poop of world.poopBlocks.values()) {
+      if (manhattan(x, y, poop.x, poop.y) <= radius) return true;
+    }
+    return false;
+  }
+
   private static _tickTreePassiveSpawns(world: World): void {
-    // Deduplicate (trees are 1x1 so each key is unique)
     for (const tree of world.treeBlocks.values()) {
       if (tree.units <= 0) continue;
-      // 2% chance seedling
-      if (Math.random() < TUNE.tree.seedlingPassiveChance) {
+      const nearPoop = SimulationEngine.hasPoopNearby(world, tree.x, tree.y, TUNE.tree.poopBoostSeedlingRadius);
+      // Seedling chance: doubled if poop nearby
+      const seedlingChance = nearPoop
+        ? TUNE.tree.seedlingPassiveChance * 2
+        : TUNE.tree.seedlingPassiveChance;
+      if (Math.random() < seedlingChance) {
         SimulationEngine.trySpawnSeedling(world, tree.x, tree.y);
       }
-      // 1% chance food (independent roll)
-      else if (Math.random() < TUNE.tree.foodPassiveChance) {
+      // Food spawn: only if poop within range
+      else if (nearPoop && Math.random() < TUNE.tree.foodPassiveChance) {
         SimulationEngine.trySpawnFoodNearTree(world, tree.x, tree.y);
       }
     }
@@ -268,19 +290,22 @@ export class SimulationEngine {
   // ── Cloud / rain ──
 
   private static _tickClouds(world: World): void {
-    // Spawn new cloud
-    world._nextCloudSpawnMs -= BASE_TICK_MS;
-    if (world._nextCloudSpawnMs <= 0) {
-      const x = rndi(0, GRID - 1);
-      const y = rndi(0, GRID - 1);
-      const lifetime = rndi(TUNE.cloud.lifetimeRange[0], TUNE.cloud.lifetimeRange[1]);
-      world.clouds.push({
-        id: uuid(), x, y,
-        spawnedAtMs: performance.now(),
-        lifetimeMs: lifetime,
-        rained: false,
-      });
-      world._nextCloudSpawnMs = rndi(TUNE.cloud.spawnIntervalRange[0], TUNE.cloud.spawnIntervalRange[1]);
+    // Spawn new cloud (rate-adjusted)
+    if (world.cloudSpawnRate > 0) {
+      world._nextCloudSpawnMs -= BASE_TICK_MS;
+      if (world._nextCloudSpawnMs <= 0) {
+        const x = rndi(0, GRID - 1);
+        const y = rndi(0, GRID - 1);
+        const lifetime = rndi(TUNE.cloud.lifetimeRange[0], TUNE.cloud.lifetimeRange[1]);
+        world.clouds.push({
+          id: uuid(), x, y,
+          spawnedAtMs: performance.now(),
+          lifetimeMs: lifetime,
+          rained: false,
+        });
+        const baseInterval = rndi(TUNE.cloud.spawnIntervalRange[0], TUNE.cloud.spawnIntervalRange[1]);
+        world._nextCloudSpawnMs = Math.max(1000, baseInterval / world.cloudSpawnRate);
+      }
     }
 
     // Update existing clouds
@@ -358,6 +383,11 @@ export class SimulationEngine {
             agent.action = ActionFactory.createHarvest(resourceType, { x: nx, y: ny }, agent.inspiration);
             return;
           }
+        }
+        // Seedlings are harvestable as low-quality food
+        if (world.seedlings.has(k) && !agent.action) {
+          agent.action = ActionFactory.createHarvest('food_lq', { x: nx, y: ny }, agent.inspiration);
+          return;
         }
       }
     }
@@ -487,6 +517,13 @@ export class SimulationEngine {
         if (!agent.action) {
           const resourceType = block.quality === 'hq' ? 'food_hq' : 'food_lq';
           agent.action = ActionFactory.createHarvest(resourceType, { x: nx, y: ny }, agent.inspiration);
+          return true;
+        }
+      }
+      // Seedlings are harvestable as low-quality food
+      if (world.seedlings.has(k)) {
+        if (!agent.action) {
+          agent.action = ActionFactory.createHarvest('food_lq', { x: nx, y: ny }, agent.inspiration);
           return true;
         }
       }
@@ -756,6 +793,14 @@ export class SimulationEngine {
           if (!agent.path && !agent.action) {
             InteractionEngine.consider(world, agent);
 
+            // Babies can only eat/drink/move — skip all other idle actions
+            if (agent.babyMsRemaining > 0) {
+              // babies just roam if they have no action
+              if (!agent.action && !agent.path) {
+                RoamingStrategy.biasedRoam(world, agent);
+              }
+            } else {
+
             // Poop trigger: 10% chance per tick for 30s after eating, only when idle
             if (!agent.action && !agent.path && agent.poopTimerMs > 0) {
               if (Math.random() < TUNE.poop.chancePerTick) {
@@ -866,7 +911,15 @@ export class SimulationEngine {
             }
           }
 
+            } // end baby guard else
+
         }
+      }
+
+      // Age-based death for agents
+      if (agent.ageTicks >= agent.maxAgeTicks) {
+        agent.health = 0;
+        log(world, 'death', `${agent.name} died of old age`, agent.id, {});
       }
 
       agent.clampStats();
@@ -903,6 +956,8 @@ export class SimulationEngine {
     SimulationEngine._applyFlagHealing(world);
     SimulationEngine._tickDiseaseSpread(world);
     SimulationEngine._cleanDead(world);
+    SimulationEngine._tickTreeAging(world);
+    SimulationEngine._tickEggs(world);
     LootBagManager.tickDecay(world, BASE_TICK_MS);
     PoopBlockManager.tickDecay(world, BASE_TICK_MS);
   }
@@ -925,6 +980,64 @@ export class SimulationEngine {
           log(world, 'hygiene', `${agent.name} spread disease to ${target.name}`, agent.id, { to: target.id });
         }
       }
+    }
+  }
+
+  private static _tickTreeAging(world: World): void {
+    const toRemove: string[] = [];
+    for (const [k, tree] of world.treeBlocks) {
+      tree.ageTotalMs += BASE_TICK_MS;
+      if (tree.ageTotalMs >= tree.maxAgeMs) {
+        toRemove.push(k);
+      }
+    }
+    for (const k of toRemove) {
+      const tree = world.treeBlocks.get(k);
+      world.treeBlocks.delete(k);
+      if (tree) log(world, 'death', `Tree @${tree.x},${tree.y} died of old age`, null, { x: tree.x, y: tree.y });
+    }
+  }
+
+  private static _tickEggs(world: World): void {
+    // Spawn eggs from trees when no agents exist
+    if (world.agents.length === 0) {
+      for (const tree of world.treeBlocks.values()) {
+        if (Math.random() < TUNE.egg.spawnChance) {
+          const adj: [number, number][] = [
+            [tree.x + 1, tree.y], [tree.x - 1, tree.y],
+            [tree.x, tree.y + 1], [tree.x, tree.y - 1],
+          ];
+          for (const [nx, ny] of adj) {
+            if (nx < 0 || ny < 0 || nx >= GRID || ny >= GRID) continue;
+            if (world.grid.isCellOccupied(nx, ny)) continue;
+            world.eggs.set(key(nx, ny), {
+              id: uuid(), x: nx, y: ny,
+              hatchTimerMs: TUNE.egg.hatchTimeMs,
+            });
+            log(world, 'spawn', `Egg appeared @${nx},${ny}`, null, { x: nx, y: ny });
+            break;
+          }
+        }
+      }
+    }
+
+    // Hatch eggs
+    const toHatch: string[] = [];
+    for (const [k, egg] of world.eggs) {
+      egg.hatchTimerMs -= BASE_TICK_MS;
+      if (egg.hatchTimerMs <= 0) toHatch.push(k);
+    }
+    for (const k of toHatch) {
+      const egg = world.eggs.get(k)!;
+      world.eggs.delete(k);
+      const babyMs = TUNE.baby.durationRange[0] + Math.random() * (TUNE.baby.durationRange[1] - TUNE.baby.durationRange[0]);
+      const agent = AgentFactory.create(world, egg.x, egg.y);
+      agent.babyMsRemaining = babyMs;
+      agent.health = 80;
+      agent.energy = 60;
+      agent.fullness = 50;
+      world.totalBirths++;
+      log(world, 'spawn', `Egg hatched into ${agent.name} @${egg.x},${egg.y}`, agent.id, {});
     }
   }
 }

--- a/src/domains/ui/controls.ts
+++ b/src/domains/ui/controls.ts
@@ -1,5 +1,5 @@
 import { key, rndi, uuid } from '../../shared/utils';
-import { GRID, LOG_CATS, OBSTACLE_EMOJIS, TUNE } from '../../shared/constants';
+import { GRID, LOG_CATS, OBSTACLE_EMOJIS, TUNE, setGridSize } from '../../shared/constants';
 import { RingLog } from '../../shared/utils';
 import type { World } from '../world';
 import { AgentFactory } from '../agent';
@@ -10,8 +10,8 @@ import { UIManager } from './ui-manager';
 
 function seedEnvironment(world: World): void {
   for (let i = 0; i < 4; i++) {
-    const x = rndi(5, 56);
-    const y = rndi(5, 56);
+    const x = rndi(5, GRID - 6);
+    const y = rndi(5, GRID - 6);
     world.farms.set(key(x, y), { id: uuid(), x, y });
   }
   // Scatter random obstacles
@@ -27,7 +27,7 @@ function seedEnvironment(world: World): void {
 }
 
 export class Controls {
-  static wire(world: World, dom: DomRefs, doRenderLog: () => void): void {
+  static wire(world: World, dom: DomRefs, doRenderLog: () => void, onWorldResize?: () => void): void {
     const { buttons, ranges, labels, nums } = dom;
 
     function spawnAgents(n: number): void {
@@ -49,10 +49,15 @@ export class Controls {
       if (nums.numSpeed) nums.numSpeed.value = ranges.rngSpeed!.value;
       world.speedPct = Number(ranges.rngSpeed!.value);
     });
-    ranges.rngSpawn?.addEventListener('input', () => {
-      if (labels.lblSpawn) labels.lblSpawn.textContent = Number(ranges.rngSpawn!.value).toFixed(1) + '\u00d7';
-      if (nums.numSpawn) nums.numSpawn.value = ranges.rngSpawn!.value;
-      world.spawnMult = Number(ranges.rngSpawn!.value);
+    ranges.rngCloudRate?.addEventListener('input', () => {
+      if (labels.lblCloudRate) labels.lblCloudRate.textContent = Number(ranges.rngCloudRate!.value).toFixed(1) + '\u00d7';
+      if (nums.numCloudRate) nums.numCloudRate.value = ranges.rngCloudRate!.value;
+      world.cloudSpawnRate = Number(ranges.rngCloudRate!.value);
+    });
+    ranges.rngWorldSize?.addEventListener('input', () => {
+      const v = Number(ranges.rngWorldSize!.value);
+      if (labels.lblWorldSize) labels.lblWorldSize.textContent = v + '\u00d7' + v;
+      if (nums.numWorldSize) nums.numWorldSize.value = ranges.rngWorldSize!.value;
     });
     nums.numAgents?.addEventListener('input', () => {
       const v = $clamp(Number(nums.numAgents!.value), 20, 300);
@@ -67,12 +72,18 @@ export class Controls {
       if (labels.lblSpeed) labels.lblSpeed.textContent = v + '%';
       world.speedPct = v;
     });
-    nums.numSpawn?.addEventListener('input', () => {
-      const v = $clamp(Number(nums.numSpawn!.value), 0.1, 5);
-      nums.numSpawn!.value = String(v);
-      if (ranges.rngSpawn) ranges.rngSpawn.value = String(v);
-      if (labels.lblSpawn) labels.lblSpawn.textContent = v.toFixed(1) + '\u00d7';
-      world.spawnMult = v;
+    nums.numCloudRate?.addEventListener('input', () => {
+      const v = $clamp(Number(nums.numCloudRate!.value), 0, 10);
+      nums.numCloudRate!.value = String(v);
+      if (ranges.rngCloudRate) ranges.rngCloudRate.value = String(v);
+      if (labels.lblCloudRate) labels.lblCloudRate.textContent = v.toFixed(1) + '\u00d7';
+      world.cloudSpawnRate = v;
+    });
+    nums.numWorldSize?.addEventListener('input', () => {
+      const v = $clamp(Number(nums.numWorldSize!.value), 20, 120);
+      nums.numWorldSize!.value = String(v);
+      if (ranges.rngWorldSize) ranges.rngWorldSize.value = String(v);
+      if (labels.lblWorldSize) labels.lblWorldSize.textContent = v + '\u00d7' + v;
     });
 
     buttons.btnStart?.addEventListener('click', () => {
@@ -88,8 +99,13 @@ export class Controls {
       world.selectedId = null;
       world.activeLogCats = new Set(LOG_CATS);
       UIManager.setupLogFilters(world, dom.logFilters, doRenderLog);
+      // Apply world size before seeding
+      const worldSize = Number(ranges.rngWorldSize?.value || 62);
+      setGridSize(worldSize);
+      world.grid.size = worldSize;
+
       world.speedPct = Number(ranges.rngSpeed?.value || 100);
-      world.spawnMult = Number(ranges.rngSpawn?.value || 1);
+      world.cloudSpawnRate = Number(ranges.rngCloudRate?.value || 1);
       seedEnvironment(world);
       spawnAgents(Number(ranges.rngAgents?.value || 20));
       world.running = true;
@@ -98,6 +114,9 @@ export class Controls {
       if (buttons.btnResume) buttons.btnResume.disabled = true;
       if (ranges.rngAgents) ranges.rngAgents.disabled = true;
       if (nums.numAgents) nums.numAgents.disabled = true;
+      if (ranges.rngWorldSize) ranges.rngWorldSize.disabled = true;
+      if (nums.numWorldSize) nums.numWorldSize.disabled = true;
+      if (onWorldResize) onWorldResize();
       world.log.push({
         t: performance.now(),
         cat: 'info',
@@ -133,6 +152,17 @@ export class Controls {
       const y = rndi(0, GRID - 1);
       const lifetime = rndi(TUNE.cloud.lifetimeRange[0], TUNE.cloud.lifetimeRange[1]);
       world.clouds.push({ id: uuid(), x, y, spawnedAtMs: performance.now(), lifetimeMs: lifetime, rained: false });
+    });
+
+    buttons.btnReplenish?.addEventListener('click', () => {
+      const next = world.paintMode === 'replenish' ? 'none' as const : 'replenish' as const;
+      world.paintMode = next;
+      buttons.btnReplenish!.classList.toggle('toggled', next === 'replenish');
+      // Deactivate other paint modes
+      if (next === 'replenish') {
+        if (dom.buttons.btnDrawObstacles) dom.buttons.btnDrawObstacles.classList.remove('toggled');
+        if (dom.buttons.btnEraseObstacles) dom.buttons.btnEraseObstacles.classList.remove('toggled');
+      }
     });
 
     buttons.btnSave?.addEventListener('click', () => PersistenceManager.export(world, doRenderLog));

--- a/src/domains/ui/input-handler.ts
+++ b/src/domains/ui/input-handler.ts
@@ -14,6 +14,9 @@ export class InputHandler {
       world.paintMode = next;
       if (btnDrawObstacles) btnDrawObstacles.classList.toggle('toggled', next === 'draw');
       if (btnEraseObstacles) btnEraseObstacles.classList.toggle('toggled', next === 'erase');
+      // Deactivate replenish when switching to draw/erase
+      const btnReplenish = dom.buttons.btnReplenish;
+      if (btnReplenish) btnReplenish.classList.remove('toggled');
     }
     btnDrawObstacles?.addEventListener('click', () => setPaintMode('draw'));
     btnEraseObstacles?.addEventListener('click', () => setPaintMode('erase'));
@@ -165,7 +168,7 @@ export class InputHandler {
       }
     });
 
-    // Agent selection
+    // Agent selection & replenish tool
     canvas.addEventListener('click', (e) => {
       const rect = canvas.getBoundingClientRect();
       const scaleX = canvas.width / rect.width;
@@ -177,6 +180,21 @@ export class InputHandler {
       const y = Math.floor(wpos.y / CELL);
       if (x < 0 || y < 0 || x >= GRID || y >= GRID) return;
       const id = world.agentsByCell.get(key(x, y));
+
+      if (world.paintMode === 'replenish' && id) {
+        const agent = world.agentsById.get(id);
+        if (agent) {
+          agent.health = agent.maxHealth;
+          agent.energy = agent.maxEnergy;
+          agent.fullness = 100;
+          agent.hygiene = 100;
+          agent.social = 100;
+          agent.inspiration = 100;
+          agent.diseased = false;
+        }
+        return;
+      }
+
       world.selectedId = id || null;
       UIManager.updateInspector(world, dom.inspector);
     });

--- a/src/domains/ui/ui-manager.ts
+++ b/src/domains/ui/ui-manager.ts
@@ -59,22 +59,26 @@ export interface DomRefs {
     btnLoad: HTMLButtonElement | null;
     btnSpawnTree: HTMLButtonElement | null;
     btnSpawnCloud: HTMLButtonElement | null;
+    btnReplenish: HTMLButtonElement | null;
   };
   fileLoad: HTMLInputElement | null;
   ranges: {
     rngAgents: HTMLInputElement | null;
     rngSpeed: HTMLInputElement | null;
-    rngSpawn: HTMLInputElement | null;
+    rngCloudRate: HTMLInputElement | null;
+    rngWorldSize: HTMLInputElement | null;
   };
   labels: {
     lblAgents: HTMLElement | null;
     lblSpeed: HTMLElement | null;
-    lblSpawn: HTMLElement | null;
+    lblCloudRate: HTMLElement | null;
+    lblWorldSize: HTMLElement | null;
   };
   nums: {
     numAgents: HTMLInputElement | null;
     numSpeed: HTMLInputElement | null;
-    numSpawn: HTMLInputElement | null;
+    numCloudRate: HTMLInputElement | null;
+    numWorldSize: HTMLInputElement | null;
   };
   statsEls: {
     stAgents: HTMLElement | null;
@@ -123,22 +127,26 @@ export class UIManager {
         btnLoad: qs('#btnLoad') as HTMLButtonElement | null,
         btnSpawnTree: qs('#btnSpawnTree') as HTMLButtonElement | null,
         btnSpawnCloud: qs('#btnSpawnCloud') as HTMLButtonElement | null,
+        btnReplenish: qs('#btnReplenish') as HTMLButtonElement | null,
       },
       fileLoad: qs('#fileLoad') as HTMLInputElement | null,
       ranges: {
         rngAgents: qs('#rngAgents') as HTMLInputElement | null,
         rngSpeed: qs('#rngSpeed') as HTMLInputElement | null,
-        rngSpawn: qs('#rngSpawn') as HTMLInputElement | null,
+        rngCloudRate: qs('#rngCloudRate') as HTMLInputElement | null,
+        rngWorldSize: qs('#rngWorldSize') as HTMLInputElement | null,
       },
       labels: {
         lblAgents: qs('#lblAgents'),
         lblSpeed: qs('#lblSpeed'),
-        lblSpawn: qs('#lblSpawn'),
+        lblCloudRate: qs('#lblCloudRate'),
+        lblWorldSize: qs('#lblWorldSize'),
       },
       nums: {
         numAgents: qs('#numAgents') as HTMLInputElement | null,
         numSpeed: qs('#numSpeed') as HTMLInputElement | null,
-        numSpawn: qs('#numSpawn') as HTMLInputElement | null,
+        numCloudRate: qs('#numCloudRate') as HTMLInputElement | null,
+        numWorldSize: qs('#numWorldSize') as HTMLInputElement | null,
       },
       statsEls: {
         stAgents: qs('#stAgents'),

--- a/src/domains/world/food-field.ts
+++ b/src/domains/world/food-field.ts
@@ -6,11 +6,13 @@ const FF_INF = 0xffff;
 const ffIdx = (x: number, y: number): number => y * GRID + x;
 
 export class FoodField {
-  readonly data: Uint16Array;
+  data: Uint16Array;
   private _lastTick = -1;
+  private _allocSize = 0;
 
   constructor() {
     const N = GRID * GRID;
+    this._allocSize = N;
     this.data = new Uint16Array(N);
     this.data.fill(FF_INF);
   }
@@ -21,6 +23,10 @@ export class FoodField {
 
   recompute(grid: Grid, tick: number): void {
     const N = GRID * GRID;
+    if (N !== this._allocSize) {
+      this._allocSize = N;
+      this.data = new Uint16Array(N);
+    }
     this.data.fill(FF_INF);
     if (grid.foodBlocks.size === 0) {
       this._lastTick = tick;

--- a/src/domains/world/grid.ts
+++ b/src/domains/world/grid.ts
@@ -1,9 +1,9 @@
 import { GRID } from '../../shared/constants';
 import { key } from '../../shared/utils';
-import type { IFoodBlock, IFarm, IObstacle, IFlag, IWaterBlock, ITreeBlock, ISeedling, ILootBag, IPoopBlock } from '../../shared/types';
+import type { IFoodBlock, IFarm, IObstacle, IFlag, IWaterBlock, ITreeBlock, ISeedling, ILootBag, IPoopBlock, IEgg } from '../../shared/types';
 
 export class Grid {
-  readonly size: number = GRID;
+  size: number = GRID;
   readonly obstacles: Map<string, IObstacle> = new Map();
   readonly foodBlocks: Map<string, IFoodBlock> = new Map();
   readonly farms: Map<string, IFarm> = new Map();
@@ -15,6 +15,7 @@ export class Grid {
   readonly seedlings: Map<string, ISeedling> = new Map();
   readonly lootBags: Map<string, ILootBag> = new Map();
   readonly poopBlocks: Map<string, IPoopBlock> = new Map();
+  readonly eggs: Map<string, IEgg> = new Map();
 
   isBlocked(x: number, y: number, ignoreId: string | null = null): boolean {
     if (x < 0 || y < 0 || x >= this.size || y >= this.size) return true;
@@ -54,7 +55,8 @@ export class Grid {
       this.treeBlocks.has(k) ||
       this.seedlings.has(k) ||
       this.poopBlocks.has(k) ||
-      this.agentsByCell.has(k)
+      this.agentsByCell.has(k) ||
+      this.eggs.has(k)
     );
   }
 
@@ -79,5 +81,6 @@ export class Grid {
     this.seedlings.clear();
     this.lootBags.clear();
     this.poopBlocks.clear();
+    this.eggs.clear();
   }
 }

--- a/src/domains/world/water-field.ts
+++ b/src/domains/world/water-field.ts
@@ -6,11 +6,13 @@ const WF_INF = 0xffff;
 const wfIdx = (x: number, y: number): number => y * GRID + x;
 
 export class WaterField {
-  readonly data: Uint16Array;
+  data: Uint16Array;
   private _lastTick = -1;
+  private _allocSize = 0;
 
   constructor() {
     const N = GRID * GRID;
+    this._allocSize = N;
     this.data = new Uint16Array(N);
     this.data.fill(WF_INF);
   }
@@ -21,6 +23,10 @@ export class WaterField {
 
   recompute(grid: Grid, tick: number): void {
     const N = GRID * GRID;
+    if (N !== this._allocSize) {
+      this._allocSize = N;
+      this.data = new Uint16Array(N);
+    }
     this.data.fill(WF_INF);
     if (grid.waterBlocks.size === 0) {
       this._lastTick = tick;

--- a/src/domains/world/world.ts
+++ b/src/domains/world/world.ts
@@ -24,7 +24,7 @@ export class World {
   totalBirths = 0;
   totalDeaths = 0;
   speedPct = 100;
-  spawnMult = 1;
+  cloudSpawnRate = 1;
   running = false;
   selectedId: string | null = null;
   paintMode: PaintMode = 'none';
@@ -62,4 +62,5 @@ export class World {
   get seedlings() { return this.grid.seedlings; }
   get lootBags() { return this.grid.lootBags; }
   get poopBlocks() { return this.grid.poopBlocks; }
+  get eggs() { return this.grid.eggs; }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Wire input + controls
   InputHandler.setup(canvas, camera, world, dom);
-  Controls.wire(world, dom, doRenderLog);
+  Controls.wire(world, dom, doRenderLog, refreshCanvasSize);
 
   // Faction sort dropdown
   if (dom.factionSortEl) {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,8 +1,13 @@
 import type { ActionType, LogCategory } from './types';
 
 export const CELL = 16;
-export const GRID = 62;
-export const WORLD_PX: number = GRID * CELL;
+export let GRID = 62;
+export let WORLD_PX: number = GRID * CELL;
+
+export function setGridSize(size: number): void {
+  GRID = size;
+  WORLD_PX = GRID * CELL;
+}
 export const BASE_TICK_MS = 250;
 export const ENERGY_CAP = 200;
 
@@ -45,7 +50,9 @@ export const TUNE = {
   shareConvertRelThreshold: 0.4,
   energyLowThreshold: 40,
   levelCap: 20,
-  maxCrops: 100,
+  agent: {
+    maxAgeRange: [240000, 360000] as [number, number],
+  },
   reproduction: { relationshipThreshold: 0.4, relationshipEnergy: 90 },
   baby: {
     durationRange: [50000, 70000] as [number, number],
@@ -125,6 +132,14 @@ export const TUNE = {
     seedlingRadius: 5,
     seedlingGrowthRange: [45000, 90000] as [number, number],
     foodRadius: 3,
+    maxAgeRange: [780000, 1020000] as [number, number],
+    waterRequiredForSeedling: 5,
+    poopBoostSeedlingRadius: 3,
+    foodRequiresPoopRadius: 3,
+  },
+  egg: {
+    hatchTimeMs: 60000,
+    spawnChance: 0.001,
   },
   cloud: {
     spawnIntervalRange: [60000, 120000] as [number, number],
@@ -153,7 +168,7 @@ export const TUNE = {
     spreadBlockThreshold: 60,
     cureHygieneThreshold: 80,
     energyDrainMultiplier: 2,
-    hpDrainPerSec: 0.8,
+    hpDrainPerSec: 0.3,
   },
   flagStorage: {
     capacityPerType: 30,
@@ -282,6 +297,7 @@ export const WORLD_EMOJIS = {
   seedling: '🌱',
   lootBag: '👝',
   poop: '💩',
+  egg: '🥚',
 } as const;
 
 export const TREE_EMOJIS: readonly string[] = ['🌲', '🌳', '🌴', '🎄'];

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -43,7 +43,7 @@ export type LogCategory =
   | 'loot'
   | 'hygiene';
 
-export type PaintMode = 'none' | 'draw' | 'erase';
+export type PaintMode = 'none' | 'draw' | 'erase' | 'replenish';
 
 export interface IActionState {
   type: ActionType;
@@ -143,6 +143,8 @@ export interface ITreeBlock {
   emoji: string;
   units: number;
   maxUnits: number;
+  ageTotalMs: number;
+  maxAgeMs: number;
 }
 
 export interface ISeedling {
@@ -168,6 +170,13 @@ export interface IPoopBlock {
   x: number;
   y: number;
   decayMs: number;
+}
+
+export interface IEgg {
+  id: string;
+  x: number;
+  y: number;
+  hatchTimerMs: number;
 }
 
 export interface ICameraState {


### PR DESCRIPTION
## Summary
- **Bug fix**: Babies can now only eat, drink, and move — all other idle actions (poop, clean, play, build, harvest, deposit) are properly guarded
- **Balance**: Disease HP drain reduced (0.8 → 0.3/s), tree seedlings require nearby water, food drops require nearby poop, poop doubles seedling spawn rate, removed global food cap
- **Aging**: Agents die of old age (~4-6 min), trees die of old age (~13-17 min), both randomized per entity
- **New features**: Cloud spawn rate slider, configurable world size (locked after start), replenish agent tool, seedlings harvestable as food, egg spawning from trees when 0 agents exist (hatch after 60s)
- **UI**: Removed HP bar above agents, replaced food spawn rate slider with cloud rate and world size controls

## Test plan
- [ ] Start simulation and verify babies only eat/drink/move
- [ ] Adjust cloud spawn rate slider and verify clouds spawn faster/slower
- [ ] Verify seedlings only appear near water blocks and food only drops near poop
- [ ] Confirm no food block cap — farms can spawn unlimited food
- [ ] Activate replenish tool and click an agent to verify stats max out
- [ ] Verify agents can harvest seedlings for food
- [ ] Change world size slider before starting, confirm grid changes and slider locks
- [ ] Verify no HP bars rendered above agents
- [ ] Kill all agents and wait for trees to spawn eggs that hatch into babies
- [ ] Wait ~5 minutes to see agents dying of old age
- [ ] Wait ~15 minutes to see trees dying of old age
- [ ] Contract disease and verify slower HP drain

🤖 Generated with [Claude Code](https://claude.com/claude-code)