### PR TITLE
feat: gameplay improvements and new systems (v3.2.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emoji-life",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": true,
   "scripts": {
     "build": "esbuild src/main.ts --bundle --outfile=dist/app.js",

--- a/src/domains/agent/agent.ts
+++ b/src/domains/agent/agent.ts
@@ -1,4 +1,4 @@
-import type { IActionState, IInventory, IPosition } from '../../shared/types';
+import type { IActionState, IInventory, IPosition, ResourceMemoryType, IResourceMemoryEntry } from '../../shared/types';
 import { TUNE, BASE_TICK_MS } from '../../shared/constants';
 import { RelationshipMap } from './relationships';
 
@@ -46,6 +46,9 @@ export class Agent {
 
   // Aging
   maxAgeTicks: number;
+
+  // Resource memory: remembers where resources were last seen
+  resourceMemory: Map<ResourceMemoryType, IResourceMemoryEntry[]>;
 
   constructor(opts: {
     id: string;
@@ -116,6 +119,10 @@ export class Agent {
     this.poopTimerMs = opts.poopTimerMs ?? 0;
     this.diseased = opts.diseased ?? false;
     this.babyMsRemaining = opts.babyMsRemaining ?? 0;
+
+    this.resourceMemory = new Map<ResourceMemoryType, IResourceMemoryEntry[]>([
+      ['food', []], ['water', []], ['wood', []],
+    ]);
 
     if (opts.maxAgeTicks != null) {
       this.maxAgeTicks = opts.maxAgeTicks;
@@ -210,5 +217,33 @@ export class Agent {
     const actual = Math.min(this.inventory[type], amount);
     this.inventory[type] -= actual;
     return actual;
+  }
+
+  // ── Resource Memory ──
+
+  rememberResource(type: ResourceMemoryType, x: number, y: number, tick: number): void {
+    const entries = this.resourceMemory.get(type)!;
+    // Don't duplicate same position
+    const existing = entries.findIndex(e => e.x === x && e.y === y);
+    if (existing >= 0) {
+      entries[existing].tick = tick;
+      return;
+    }
+    if (entries.length >= TUNE.agent.maxResourceMemory) {
+      // Replace oldest entry
+      let oldestIdx = 0;
+      for (let i = 1; i < entries.length; i++) {
+        if (entries[i].tick < entries[oldestIdx].tick) oldestIdx = i;
+      }
+      entries[oldestIdx] = { x, y, tick };
+    } else {
+      entries.push({ x, y, tick });
+    }
+  }
+
+  forgetResource(type: ResourceMemoryType, x: number, y: number): void {
+    const entries = this.resourceMemory.get(type)!;
+    const idx = entries.findIndex(e => e.x === x && e.y === y);
+    if (idx >= 0) entries.splice(idx, 1);
   }
 }

--- a/src/domains/simulation/simulation-engine.ts
+++ b/src/domains/simulation/simulation-engine.ts
@@ -1,4 +1,5 @@
 import { GRID, BASE_TICK_MS, TUNE, FOOD_EMOJIS, TREE_EMOJIS, WORLD_EMOJIS } from '../../shared/constants';
+import type { ResourceMemoryType } from '../../shared/types';
 import { key, manhattan, rndi, log, uuid } from '../../shared/utils';
 import { Pathfinder } from '../../shared/pathfinding';
 import { FoodField } from '../world/food-field';
@@ -287,10 +288,78 @@ export class SimulationEngine {
     }
   }
 
+  // ── Water decay ──
+
+  private static _tickWaterDecay(world: World): void {
+    const toDelete: string[] = [];
+    const seen = new Set<string>();
+    for (const [k, wb] of world.waterBlocks) {
+      if (seen.has(wb.id)) continue;
+      seen.add(wb.id);
+      wb.units -= TUNE.water.baseDecayPerTick;
+      if (wb.units <= 0) {
+        for (const c of wb.cells) toDelete.push(key(c.x, c.y));
+      } else if (wb.size === 'large' && wb.units < wb.maxUnits * TUNE.water.shrinkThreshold) {
+        // Shrink large to small (keep first cell only)
+        const keep = wb.cells[0];
+        for (let i = 1; i < wb.cells.length; i++) {
+          world.waterBlocks.delete(key(wb.cells[i].x, wb.cells[i].y));
+        }
+        wb.size = 'small' as const;
+        wb.cells = [keep];
+        wb.x = keep.x;
+        wb.y = keep.y;
+      }
+    }
+    for (const k of toDelete) world.waterBlocks.delete(k);
+  }
+
+  // ── Seedling near water ──
+
+  private static _tickSeedlingNearWater(world: World): void {
+    const seen = new Set<string>();
+    for (const wb of world.waterBlocks.values()) {
+      if (seen.has(wb.id)) continue;
+      seen.add(wb.id);
+      if (Math.random() < TUNE.tree.seedlingNearWaterChance) {
+        // Spawn seedling within 3 cells of this water block
+        for (let attempt = 0; attempt < 10; attempt++) {
+          const x = wb.x + rndi(-3, 3);
+          const y = wb.y + rndi(-3, 3);
+          if (x < 0 || y < 0 || x >= GRID || y >= GRID) continue;
+          if (world.grid.isCellOccupied(x, y)) continue;
+          const dur = rndi(TUNE.tree.seedlingGrowthRange[0], TUNE.tree.seedlingGrowthRange[1]);
+          world.seedlings.set(key(x, y), {
+            id: uuid(), x, y,
+            plantedAtTick: world.tick,
+            growthDurationMs: dur,
+            growthElapsedMs: 0,
+          });
+          break;
+        }
+      }
+    }
+  }
+
   // ── Cloud / rain ──
 
   private static _tickClouds(world: World): void {
-    // Spawn new cloud (rate-adjusted)
+    // Dynamic cloud spawn rate based on water coverage
+    const totalCells = GRID * GRID;
+    const seenWater = new Set<string>();
+    let waterCellCount = 0;
+    for (const wb of world.waterBlocks.values()) {
+      if (!seenWater.has(wb.id)) {
+        seenWater.add(wb.id);
+        waterCellCount += wb.cells.length;
+      }
+    }
+    const currentCoverage = waterCellCount / totalCells;
+    const target = TUNE.cloud.targetWaterCoverage;
+    // Scale: when coverage is 0, rate multiplier is ~3x; when at target, ~1x; when 2x target, ~0.2x
+    const dynamicMultiplier = Math.max(0.1, Math.min(4, (target / Math.max(0.001, currentCoverage))));
+
+    // Spawn new cloud (rate-adjusted by both slider and dynamic multiplier)
     if (world.cloudSpawnRate > 0) {
       world._nextCloudSpawnMs -= BASE_TICK_MS;
       if (world._nextCloudSpawnMs <= 0) {
@@ -304,7 +373,7 @@ export class SimulationEngine {
           rained: false,
         });
         const baseInterval = rndi(TUNE.cloud.spawnIntervalRange[0], TUNE.cloud.spawnIntervalRange[1]);
-        world._nextCloudSpawnMs = Math.max(1000, baseInterval / world.cloudSpawnRate);
+        world._nextCloudSpawnMs = Math.max(1000, baseInterval / (world.cloudSpawnRate * dynamicMultiplier));
       }
     }
 
@@ -331,6 +400,83 @@ export class SimulationEngine {
       }
     }
     world.clouds = remaining;
+  }
+
+  // ── Vision scan — agents observe nearby resources ──
+
+  static scanVision(world: World, agent: Agent): void {
+    const range = TUNE.agent.visionRange;
+    const x0 = Math.max(0, agent.cellX - range);
+    const x1 = Math.min(GRID - 1, agent.cellX + range);
+    const y0 = Math.max(0, agent.cellY - range);
+    const y1 = Math.min(GRID - 1, agent.cellY + range);
+
+    for (let x = x0; x <= x1; x++) {
+      for (let y = y0; y <= y1; y++) {
+        if (manhattan(agent.cellX, agent.cellY, x, y) > range) continue;
+        const k = key(x, y);
+        if (world.foodBlocks.has(k) || world.seedlings.has(k)) {
+          agent.rememberResource('food', x, y, world.tick);
+        }
+        if (world.waterBlocks.has(k)) {
+          agent.rememberResource('water', x, y, world.tick);
+        }
+        if (world.treeBlocks.has(k)) {
+          agent.rememberResource('wood', x, y, world.tick);
+        }
+      }
+    }
+  }
+
+  /** Try to pathfind to a remembered resource location. Returns true if path was set. */
+  static seekFromMemory(world: World, agent: Agent, type: ResourceMemoryType): boolean {
+    const entries = agent.resourceMemory.get(type)!;
+    if (entries.length === 0) return false;
+
+    // Check each remembered location — if resource is gone, forget it
+    let bestIdx = -1;
+    let bestDist = Infinity;
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const e = entries[i];
+      const k = key(e.x, e.y);
+      let stillExists = false;
+      if (type === 'food') {
+        stillExists = world.foodBlocks.has(k) || world.seedlings.has(k);
+      } else if (type === 'water') {
+        stillExists = world.waterBlocks.has(k);
+      } else {
+        stillExists = world.treeBlocks.has(k);
+      }
+      if (!stillExists) {
+        entries.splice(i, 1);
+        continue;
+      }
+      const d = manhattan(agent.cellX, agent.cellY, e.x, e.y);
+      if (d < bestDist) {
+        bestDist = d;
+        bestIdx = i;
+      }
+    }
+
+    if (bestIdx < 0) return false;
+    const target = entries[bestIdx];
+    // For water, target adjacent cell (water is impassable)
+    if (type === 'water') {
+      const adjCells: [number, number][] = [
+        [target.x + 1, target.y], [target.x - 1, target.y],
+        [target.x, target.y + 1], [target.x, target.y - 1],
+      ];
+      for (const [ax, ay] of adjCells) {
+        if (ax < 0 || ay < 0 || ax >= GRID || ay >= GRID) continue;
+        if (!world.grid.isBlocked(ax, ay, agent.id)) {
+          Pathfinder.planPathTo(world, agent, ax, ay);
+          return agent.path !== null && agent.path.length > 0;
+        }
+      }
+      return false;
+    }
+    Pathfinder.planPathTo(world, agent, target.x, target.y);
+    return agent.path !== null && agent.path.length > 0;
   }
 
   // ── Food seeking ──
@@ -392,7 +538,34 @@ export class SimulationEngine {
       }
     }
 
-    // 3. Pathfind to nearest food block
+    // 3. Look within vision range for food
+    const vr = TUNE.agent.visionRange;
+    let closestFood: { x: number; y: number; d: number } | null = null;
+    for (let dx = -vr; dx <= vr; dx++) {
+      for (let dy = -vr; dy <= vr; dy++) {
+        const d = Math.abs(dx) + Math.abs(dy);
+        if (d > vr) continue;
+        const fx = agent.cellX + dx;
+        const fy = agent.cellY + dy;
+        if (fx < 0 || fy < 0 || fx >= GRID || fy >= GRID) continue;
+        const k = key(fx, fy);
+        const block = world.foodBlocks.get(k);
+        if ((block && block.units > 0 && !world.flagCells.has(k)) || world.seedlings.has(k)) {
+          if (!closestFood || d < closestFood.d) {
+            closestFood = { x: fx, y: fy, d };
+          }
+        }
+      }
+    }
+    if (closestFood) {
+      Pathfinder.planPathTo(world, agent, closestFood.x, closestFood.y);
+      if (agent.path && agent.path.length > 0) return;
+    }
+
+    // 4. Use resource memory
+    if (SimulationEngine.seekFromMemory(world, agent, 'food')) return;
+
+    // 5. Full pathfind (global search)
     if (world.tick - world.foodField.lastTick >= 5) {
       world.foodField.recompute(world.grid, world.tick);
     }
@@ -410,6 +583,9 @@ export class SimulationEngine {
         return;
       }
     }
+
+    // 6. Nothing found — wander
+    RoamingStrategy.biasedRoam(world, agent);
   }
 
   // ── Water seeking ──
@@ -465,7 +641,43 @@ export class SimulationEngine {
       }
     }
 
-    // 3. Pathfind to nearest water block
+    // 3. Look within vision range for water
+    const vr = TUNE.agent.visionRange;
+    let closestWater: { x: number; y: number; d: number } | null = null;
+    for (let dx = -vr; dx <= vr; dx++) {
+      for (let dy = -vr; dy <= vr; dy++) {
+        const d = Math.abs(dx) + Math.abs(dy);
+        if (d > vr) continue;
+        const wx = agent.cellX + dx;
+        const wy = agent.cellY + dy;
+        if (wx < 0 || wy < 0 || wx >= GRID || wy >= GRID) continue;
+        const block = world.waterBlocks.get(key(wx, wy));
+        if (block && block.units > 0) {
+          if (!closestWater || d < closestWater.d) {
+            closestWater = { x: wx, y: wy, d };
+          }
+        }
+      }
+    }
+    if (closestWater) {
+      // Target adjacent cell to water (water is impassable)
+      const adjCells: [number, number][] = [
+        [closestWater.x + 1, closestWater.y], [closestWater.x - 1, closestWater.y],
+        [closestWater.x, closestWater.y + 1], [closestWater.x, closestWater.y - 1],
+      ];
+      for (const [ax, ay] of adjCells) {
+        if (ax < 0 || ay < 0 || ax >= GRID || ay >= GRID) continue;
+        if (!world.grid.isBlocked(ax, ay, agent.id)) {
+          Pathfinder.planPathTo(world, agent, ax, ay);
+          if (agent.path && agent.path.length > 0) return;
+        }
+      }
+    }
+
+    // 4. Use resource memory
+    if (SimulationEngine.seekFromMemory(world, agent, 'water')) return;
+
+    // 5. Full pathfind (global search)
     if (world.tick - world.waterField.lastTick >= 5) {
       world.waterField.recompute(world.grid, world.tick);
     }
@@ -479,11 +691,11 @@ export class SimulationEngine {
       seen.add(wb.id);
       // Target adjacent cells, not the water itself (it's impassable)
       for (const c of wb.cells) {
-        const adjCells: [number, number][] = [
+        const adjWater: [number, number][] = [
           [c.x + 1, c.y], [c.x - 1, c.y],
           [c.x, c.y + 1], [c.x, c.y - 1],
         ];
-        for (const [ax, ay] of adjCells) {
+        for (const [ax, ay] of adjWater) {
           if (ax < 0 || ay < 0 || ax >= GRID || ay >= GRID) continue;
           if (!world.grid.isBlocked(ax, ay, agent.id)) {
             waterPositions.push({ x: ax, y: ay });
@@ -495,8 +707,12 @@ export class SimulationEngine {
       const near = Pathfinder.findNearest(agent, waterPositions);
       if (near) {
         Pathfinder.planPathTo(world, agent, near.target.x, near.target.y);
+        return;
       }
     }
+
+    // 6. Nothing found — wander
+    RoamingStrategy.biasedRoam(world, agent);
   }
 
   // ── Opportunistic resource harvest ──
@@ -660,6 +876,8 @@ export class SimulationEngine {
     SimulationEngine._tickSeedlings(world);
     SimulationEngine._tickTreePassiveSpawns(world);
     SimulationEngine._tickClouds(world);
+    SimulationEngine._tickWaterDecay(world);
+    SimulationEngine._tickSeedlingNearWater(world);
 
     for (const b of world.agents) b._underAttack = false;
     for (const b of world.agents) {
@@ -678,6 +896,8 @@ export class SimulationEngine {
       agent.drainFullness(TUNE.fullness.passiveDecay);
       // Passive inspiration decay
       agent.inspiration = Math.max(0, agent.inspiration - TUNE.inspiration.passiveDecay);
+      // Passive social decay
+      agent.social = Math.max(0, agent.social - TUNE.social.passiveDecay);
       // Poop timer decay
       if (agent.poopTimerMs > 0) agent.poopTimerMs -= BASE_TICK_MS;
       agent.lockMsRemaining = Math.max(0, (agent.lockMsRemaining || 0) - BASE_TICK_MS);
@@ -787,6 +1007,11 @@ export class SimulationEngine {
             } else if (!occupant) {
               world.agentsByCell.set(ck, agent.id);
             }
+          }
+
+          // Vision scan — update resource memory
+          if (!agent.action) {
+            SimulationEngine.scanVision(world, agent);
           }
 
           // Idle decision — delegate to InteractionEngine for priority hierarchy

--- a/src/domains/ui/ui-manager.ts
+++ b/src/domains/ui/ui-manager.ts
@@ -485,7 +485,6 @@ export class UIManager {
         <div style="color:var(--muted)">ATTACK</div><div>${a.attack.toFixed(1)}</div>
         <div style="color:var(--muted)">XP</div><div>${a.xp} / ${a.xpToNextLevel()}</div>
         <div style="color:var(--muted)">AGE</div><div>${a.ageTicks} ticks</div>
-        <div style="color:var(--muted)">INSPIRATION</div><div>${a.inspiration.toFixed(0)}</div>
       </div>`;
   }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -52,6 +52,8 @@ export const TUNE = {
   levelCap: 20,
   agent: {
     maxAgeRange: [240000, 360000] as [number, number],
+    visionRange: 10,
+    maxResourceMemory: 2,
   },
   reproduction: { relationshipThreshold: 0.4, relationshipEnergy: 90 },
   baby: {
@@ -74,6 +76,9 @@ export const TUNE = {
     hygieneStart: 50,
     socialStart: 50,
     inspirationStart: 50,
+  },
+  social: {
+    passiveDecay: 0.01,
   },
   xp: {
     perKill: 50,
@@ -121,6 +126,7 @@ export const TUNE = {
     largeUnits: 20,
     spawnRange: [3, 6] as [number, number],
     shrinkThreshold: 0.25,
+    baseDecayPerTick: 0.008,
   },
   tree: {
     spawnRange: [8, 15] as [number, number],
@@ -136,6 +142,7 @@ export const TUNE = {
     waterRequiredForSeedling: 5,
     poopBoostSeedlingRadius: 3,
     foodRequiresPoopRadius: 3,
+    seedlingNearWaterChance: 0.0005,
   },
   egg: {
     hatchTimeMs: 60000,
@@ -145,6 +152,7 @@ export const TUNE = {
     spawnIntervalRange: [60000, 120000] as [number, number],
     lifetimeRange: [5000, 10000] as [number, number],
     smallChance: 0.9,
+    targetWaterCoverage: 0.05,
   },
   hygiene: {
     criticalThreshold: 20,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -179,6 +179,14 @@ export interface IEgg {
   hatchTimerMs: number;
 }
 
+export type ResourceMemoryType = 'food' | 'water' | 'wood';
+
+export interface IResourceMemoryEntry {
+  x: number;
+  y: number;
+  tick: number;
+}
+
 export interface ICameraState {
   x: number;
   y: number;

--- a/tech_specs.md
+++ b/tech_specs.md
@@ -1,4 +1,4 @@
-# Emoji Life — Technical Specification (v3.2.0, 2026-03-25)
+# Emoji Life — Technical Specification (v3.2.4, 2026-03-26)
 
 ## Purpose
 
@@ -63,7 +63,7 @@ Agent {
   // Needs system
   fullness: float           // 0..100; passive decay, restored by eating
   hygiene: float            // 0..100; decay from movement/actions/poop, restored by drinking water
-  social: float             // 0..100 (placeholder, not active)
+  social: float             // 0..100; passive decay −0.01/tick; recovered by sharing (+8 sharer, +5 recipient)
   inspiration: float        // 0..100; passive decay −0.015/tick; recovered by play (+15), clean (+10), build farm (+25)
 
   // Disease system (Phase 5)
@@ -76,6 +76,9 @@ Agent {
     water: int              // 0..20 (shared cap)
     wood: int               // 0..20 (shared cap)
   }                         // Total units across all types capped at 20
+
+  // Resource memory (v3.2.4)
+  resourceMemory: Map<'food'|'water'|'wood', {x,y,tick}[]>  // up to 2 coords per type (max 6 total)
 
   action: null | {
     type: 'talk'|'quarrel'|'attack'|'under_attack'|'heal'|'share'|'attack_wall'|'attack_flag'|'reproduce'|'sleep'|'harvest'|'harvest_water'|'harvest_wood'|'eat'|'drink'|'deposit'|'withdraw'|'pickup'|'poop'|'clean'|'play'|'build_farm'
@@ -192,7 +195,7 @@ This scaling is applied once when the action is created, not continuously during
 
 #### Placeholder Needs
 
-* **Social:** starts 50 (tracked on agents but no gameplay effect)
+* **Social:** starts 50, passive decay −0.01/tick; recovered by sharing
 
 ### 3.3 Resources & Inventory
 
@@ -236,14 +239,18 @@ Water exists as blocks on the grid that agents harvest for drinking water.
 | Harvest time per unit | 1000ms | 1000ms |
 | Shrinking | N/A | Shrinks to small at 25% threshold (≤5 units) |
 | Depletion | Block removed when 0 units remain | Becomes small water block at ≤5 units |
+| Base decay | −0.008 units/tick | −0.008 units/tick (same rate) |
+
+**Seedling spawning near water:** Each water block has a very small chance (0.05%) per tick to spawn a seedling within 3 cells of it.
 
 **World-gen water:** 3–6 water sources placed at world creation (mix of small and large).
 
-**Cloud/rain system:** Clouds spawn periodically to replenish water on the map.
+**Cloud/rain system:** Clouds spawn periodically to replenish water on the map. Cloud spawn rate is **dynamic** — when water coverage is low, clouds spawn faster; when coverage approaches the 5% target, clouds spawn at the base rate; above target, clouds slow down. The UI slider acts as a global multiplier on top of this dynamic rate.
 
 | Property | Value |
 |----------|-------|
-| Cloud spawn rate | 1 cloud every 60–120 seconds |
+| Cloud spawn rate | Base: 1 cloud every 60–120 seconds (dynamically scaled by water coverage) |
+| Target water coverage | ~5% of grid cells |
 | Cloud duration | 5–10 seconds |
 | Cloud emoji | 🌧️ |
 | Rain spawn | Spawns water blocks below the cloud |
@@ -714,8 +721,8 @@ Faction flags now store resources for the faction.
      1. Energy < 20 → mandatory sleep
      2. Under attack → flee/retaliate
      3. Health < 30% maxHP → seek faction flag
-     4. Fullness < 20 → urgent food seeking: eat from inventory first; if no food in inventory, harvest adjacent food block; if none adjacent, pathfind to nearest food block
-     5. Hygiene < 20 → critical water seeking: drink from inventory first; if no water in inventory, harvest adjacent water block; if none adjacent, pathfind to nearest water block
+     4. Fullness < 20 → urgent food seeking: eat from inventory first; if no food in inventory, harvest adjacent food block; if none adjacent, scan within vision range (10 cells), check resource memory, then full pathfind; if nothing found, wander
+     5. Hygiene < 20 → critical water seeking: drink from inventory first; if no water in inventory, harvest adjacent water block; if none adjacent, scan within vision range (10 cells), check resource memory, then full pathfind; if nothing found, wander
      6. Energy < 40 → voluntary sleep
      7. Normal state:
         a. Fullness < 40 → proactive food seeking (same eat/harvest/pathfind priority as above); withdraw from own flag if nearby and flag has food
@@ -727,7 +734,16 @@ Faction flags now store resources for the faction.
         f. Pickup loot bags (before roaming)
         g. Clean adjacent poop block (opportunistic)
         h. Reproduction, attack, share/heal/talk
-        i. Roam
+        i. Roam (only if vision scan + resource memory + full pathfind all fail)
+
+   **Vision & Resource Memory (v3.2.4):**
+   * Agents have a **line of sight of 10 cells** (Manhattan distance)
+   * Each tick (when idle), agents scan their vision range and remember resource locations
+   * **Resource memory:** up to 2 coordinates per resource type (food, water, wood), max 6 total
+   * When a new resource is spotted and memory is full, the oldest entry for that type is replaced
+   * When seeking a resource: (1) check adjacent cells, (2) scan within vision range, (3) check resource memory, (4) full pathfind, (5) wander
+   * If an agent travels to a remembered location and the resource is gone, the memory entry is deleted
+
    * If acting: process action (distance rules; energy drain; effects)
    * If not acting:
 
@@ -878,6 +894,15 @@ Faction flags now store resources for the faction.
 * **Build farm reworked:** the old random-chance farm building mechanic is replaced by an explicit `build_farm` action. Requires 3 wood in inventory + 6 energy. Duration: 2000ms fixed, 0.25 energy/sec. Spawns a farm (🌻) on an adjacent free cell. Grants +15 XP and +25 inspiration.
 * **Farm spawn system reworked:** each farm now tracks `spawnsRemaining` (starts at 10) and `spawnTimerMs` (15–25 second interval between spawns). Farms spawn HQ food on adjacent cells (radius 1), with a maximum of 4 food blocks within radius 1. When `spawnsRemaining` reaches 0, the farm is destroyed and removed from the grid.
 * **Decision priority updated:** inspiration < 40 inserted at priority 7c (seek play or clean poop). Old poop check moved to priority 7c2.
+
+### v3.2.4 — Balance & Enhancements
+
+* **Water blocks now decay:** base decay rate of −0.008 units/tick. Water blocks naturally evaporate over time and need cloud replenishment.
+* **Dynamic cloud spawn rate:** cloud spawn frequency now scales inversely with current water coverage. Target is ~5% grid coverage. The UI slider acts as a global multiplier on top of the dynamic rate.
+* **Seedlings near water:** each water block has a 0.05% chance per tick to spontaneously spawn a seedling within 3 cells.
+* **Social need now decays:** passive decay at −0.01/tick (was placeholder with no decay). Social need is recovered via sharing (+8 sharer, +5 recipient).
+* **Inspiration text removed from inspector panel:** the details grid no longer shows the redundant text value — the bar remains.
+* **Agent vision system:** agents now have a 10-cell Manhattan distance line of sight. They scan visible resources each tick and maintain a resource memory (up to 2 coordinates per type: food, water, wood; max 6 total). Resource seeking now follows: adjacent → vision range → memory → full pathfind → wander. Stale memory entries are cleaned up when the agent visits the location and the resource is gone.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Water decay**: Water blocks now lose 0.008 units/tick passively, requiring cloud replenishment to maintain supply
- **Dynamic cloud rate**: Cloud spawn frequency scales inversely with water coverage, targeting ~5% grid coverage; UI slider remains as a global multiplier
- **Seedlings near water**: Each water block has a 0.05% chance/tick to spontaneously spawn a seedling within 3 cells
- **Social decay**: Social need now decays at −0.01/tick (was a placeholder with no decay); recovered via sharing
- **Inspector cleanup**: Removed redundant inspiration text from details grid (bar in stats section remains)
- **Agent vision + resource memory**: Agents have 10-cell line of sight, scan resources each tick, and remember up to 2 locations per resource type (food/water/wood); seeking order: adjacent → vision → memory → full pathfind → wander; stale memory entries are pruned automatically

## Test plan

- [ ] Confirm water blocks gradually shrink and disappear over time without harvesting
- [ ] Observe that clouds spawn more frequently when water is scarce and less when water is plentiful
- [ ] Verify seedlings occasionally appear near water blocks spontaneously
- [ ] Confirm social stat now visibly decreases over time in the inspector panel
- [ ] Check inspector panel — inspiration bar is visible but text value is gone from the details grid
- [ ] Watch agents wander when no food/water is visible or in memory, then navigate toward resources when spotted

🤖 Generated with [Claude Code](https://claude.ai/claude-code)