### PR TITLE
feat: gameplay enhancements v3.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emoji-life",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "private": true,
   "scripts": {
     "build": "esbuild src/main.ts --bundle --outfile=dist/app.js",

--- a/src/domains/action/action-processor.ts
+++ b/src/domains/action/action-processor.ts
@@ -262,6 +262,7 @@ export class ActionProcessor {
           else chosen = pa || pb;
           if (chosen) FactionManager.setFaction(world, child, chosen, 'birth');
           world.totalBirths++;
+          world.birthTimestamps.push(performance.now());
           log(world, 'reproduce', `${agent.name} & ${targ.name} had ${child.name}`, agent.id, { child: child.id });
         }
       }
@@ -353,7 +354,10 @@ export class ActionProcessor {
       if (hasPoop) SimulationEngine.trySpawnFoodNearTree(world, tree.x, tree.y);
     }
 
-    if (tree.units <= 0) world.treeBlocks.delete(k);
+    if (tree.units <= 0) {
+      world.treeBlocks.delete(k);
+      world.deadMarkers.push({ cellX: tree.x, cellY: tree.y, cause: 'tree', msRemaining: 3000 });
+    }
     ActionProcessor._checkLevelUp(world, agent);
   }
 

--- a/src/domains/action/action-processor.ts
+++ b/src/domains/action/action-processor.ts
@@ -356,7 +356,7 @@ export class ActionProcessor {
 
     if (tree.units <= 0) {
       world.treeBlocks.delete(k);
-      world.deadMarkers.push({ cellX: tree.x, cellY: tree.y, cause: 'tree', msRemaining: 3000 });
+      world.deadMarkers.push({ cellX: tree.x, cellY: tree.y, cause: 'tree', msRemaining: 10000 });
     }
     ActionProcessor._checkLevelUp(world, agent);
   }

--- a/src/domains/rendering/renderer.ts
+++ b/src/domains/rendering/renderer.ts
@@ -1,9 +1,17 @@
 import { CELL, GRID, COLORS, AGENT_EMOJIS, IDLE_EMOJIS, WORLD_EMOJIS, FOOD_EMOJIS, TUNE } from '../../shared/constants';
 import { getIdleEmoji } from '../../shared/utils';
-import type { World } from '../world';
+import type { World, DeathCause } from '../world';
 import type { Agent } from '../agent';
 import { Camera } from './camera';
 import { EmojiCache } from './emoji-cache';
+
+const DEATH_CAUSE_EMOJI: Record<DeathCause, string> = {
+  hunger: '\u{1F9B4}',   // 🦴
+  killed: '\u{1FA78}',   // 🩸
+  disease: '\u{1F9A0}',  // 🦠
+  old_age: '\u{1F9B4}',  // 🦴
+  tree: '\u{1FABE}',     // 🪾
+};
 
 export class Renderer {
   private readonly _emojiCache = new EmojiCache();
@@ -31,6 +39,7 @@ export class Renderer {
 
     const pendingAttackLines: [Agent, Agent][] = [];
     this._drawAgents(ctx, world, pendingAttackLines);
+    this._drawDeadMarkers(ctx, world);
     this._drawAttackLines(ctx, camera, pendingAttackLines);
 
     this._drawClouds(ctx, world, camera);
@@ -230,6 +239,40 @@ export class Renderer {
     ctx.fill();
     ctx.stroke();
     ctx.restore();
+  }
+
+  private _drawDeadMarkers(ctx: CanvasRenderingContext2D, world: World): void {
+    for (const marker of world.deadMarkers) {
+      const x = marker.cellX * CELL;
+      const y = marker.cellY * CELL;
+      const fade = Math.min(1, marker.msRemaining / 1000);
+      ctx.globalAlpha = fade;
+
+      if (marker.cause === 'tree') {
+        // Tree death: show stump emoji at full cell size
+        const stumpEmoji = DEATH_CAUSE_EMOJI.tree;
+        const { canvas: sc, w: sw, h: sh } = this._emojiCache.get(stumpEmoji);
+        const drawSize = CELL - 2;
+        const scale = Math.min(drawSize / sw, drawSize / sh);
+        ctx.drawImage(sc, x + (CELL - sw * scale) / 2, y + (CELL - sh * scale) / 2, sw * scale, sh * scale);
+      } else {
+        // Agent death: draw 😵 at full agent size
+        const deadEmoji = '\u{1F635}'; // 😵
+        const { canvas: ec, w, h } = this._emojiCache.get(deadEmoji);
+        const drawSize = CELL - 4;
+        const scale = Math.min(drawSize / w, drawSize / h);
+        ctx.drawImage(ec, x + (CELL - w * scale) / 2, y + (CELL - h * scale) / 2, w * scale, h * scale);
+
+        // Draw cause icon at 1/4 size, offset to top-right
+        const causeEmoji = DEATH_CAUSE_EMOJI[marker.cause];
+        const { canvas: cc, w: cw, h: ch } = this._emojiCache.get(causeEmoji);
+        const causeSize = CELL / 4;
+        const cScale = Math.min(causeSize / cw, causeSize / ch);
+        ctx.drawImage(cc, x + CELL - cw * cScale - 1, y + 1, cw * cScale, ch * cScale);
+      }
+
+      ctx.globalAlpha = 1;
+    }
   }
 
   private _drawAttackLines(ctx: CanvasRenderingContext2D, camera: Camera, lines: [Agent, Agent][]): void {

--- a/src/domains/rendering/renderer.ts
+++ b/src/domains/rendering/renderer.ts
@@ -9,7 +9,7 @@ const DEATH_CAUSE_EMOJI: Record<DeathCause, string> = {
   hunger: '\u{1F9B4}',   // 🦴
   killed: '\u{1FA78}',   // 🩸
   disease: '\u{1F9A0}',  // 🦠
-  old_age: '\u{1F9B4}',  // 🦴
+  old_age: '\u{1F550}',  // 🕐
   tree: '\u{1FABE}',     // 🪾
 };
 
@@ -245,7 +245,7 @@ export class Renderer {
     for (const marker of world.deadMarkers) {
       const x = marker.cellX * CELL;
       const y = marker.cellY * CELL;
-      const fade = Math.min(1, marker.msRemaining / 1000);
+      const fade = Math.min(1, marker.msRemaining / 3000);
       ctx.globalAlpha = fade;
 
       if (marker.cause === 'tree') {

--- a/src/domains/simulation/simulation-engine.ts
+++ b/src/domains/simulation/simulation-engine.ts
@@ -6,7 +6,7 @@ import { FoodField } from '../world/food-field';
 import { WaterField } from '../world/water-field';
 import { LootBagManager } from '../world/loot-bag-manager';
 import { PoopBlockManager } from '../world/poop-block-manager';
-import type { World } from '../world';
+import type { World, DeathCause } from '../world';
 import type { Agent } from '../agent';
 import { ActionFactory, ActionProcessor, InteractionEngine } from '../action';
 import { AgentFactory } from '../agent/agent-factory';
@@ -434,7 +434,7 @@ export class SimulationEngine {
     if (entries.length === 0) return false;
 
     // Check each remembered location — if resource is gone, forget it
-    let bestIdx = -1;
+    let bestEntry: { x: number; y: number; tick: number } | null = null;
     let bestDist = Infinity;
     for (let i = entries.length - 1; i >= 0; i--) {
       const e = entries[i];
@@ -454,12 +454,12 @@ export class SimulationEngine {
       const d = manhattan(agent.cellX, agent.cellY, e.x, e.y);
       if (d < bestDist) {
         bestDist = d;
-        bestIdx = i;
+        bestEntry = e;
       }
     }
 
-    if (bestIdx < 0) return false;
-    const target = entries[bestIdx];
+    if (!bestEntry) return false;
+    const target = bestEntry;
     // For water, target adjacent cell (water is impassable)
     if (type === 'water') {
       const adjCells: [number, number][] = [
@@ -797,6 +797,7 @@ export class SimulationEngine {
 
   private static _cleanDead(world: World): void {
     const removedIds: string[] = [];
+    const now = performance.now();
     world.agents = world.agents.filter((a) => {
       if (a.health <= 0) {
         LootBagManager.dropOnDeath(world, a);
@@ -807,6 +808,22 @@ export class SimulationEngine {
           world.factions.get(a.factionId)!.members.delete(a.id);
         }
         world.totalDeaths++;
+        world.deathTimestamps.push(now);
+
+        // Determine death cause
+        let cause: DeathCause = 'killed';
+        if (a.ageTicks >= a.maxAgeTicks) {
+          cause = 'old_age';
+        } else if (a.fullness <= 0) {
+          cause = 'hunger';
+        } else if (a.diseased) {
+          cause = 'disease';
+        }
+        world.deadMarkers.push({
+          cellX: a.cellX, cellY: a.cellY,
+          cause, msRemaining: 3000,
+        });
+
         log(world, 'death', `${a.name} died`, a.id, {});
         return false;
       }
@@ -1219,7 +1236,10 @@ export class SimulationEngine {
     for (const k of toRemove) {
       const tree = world.treeBlocks.get(k);
       world.treeBlocks.delete(k);
-      if (tree) log(world, 'death', `Tree @${tree.x},${tree.y} died of old age`, null, { x: tree.x, y: tree.y });
+      if (tree) {
+        world.deadMarkers.push({ cellX: tree.x, cellY: tree.y, cause: 'tree', msRemaining: 3000 });
+        log(world, 'death', `Tree @${tree.x},${tree.y} died of old age`, null, { x: tree.x, y: tree.y });
+      }
     }
   }
 
@@ -1262,6 +1282,7 @@ export class SimulationEngine {
       agent.energy = 60;
       agent.fullness = 50;
       world.totalBirths++;
+      world.birthTimestamps.push(performance.now());
       log(world, 'spawn', `Egg hatched into ${agent.name} @${egg.x},${egg.y}`, agent.id, {});
     }
   }

--- a/src/domains/simulation/simulation-engine.ts
+++ b/src/domains/simulation/simulation-engine.ts
@@ -821,7 +821,7 @@ export class SimulationEngine {
         }
         world.deadMarkers.push({
           cellX: a.cellX, cellY: a.cellY,
-          cause, msRemaining: 3000,
+          cause, msRemaining: 10000,
         });
 
         log(world, 'death', `${a.name} died`, a.id, {});
@@ -1237,7 +1237,7 @@ export class SimulationEngine {
       const tree = world.treeBlocks.get(k);
       world.treeBlocks.delete(k);
       if (tree) {
-        world.deadMarkers.push({ cellX: tree.x, cellY: tree.y, cause: 'tree', msRemaining: 3000 });
+        world.deadMarkers.push({ cellX: tree.x, cellY: tree.y, cause: 'tree', msRemaining: 10000 });
         log(world, 'death', `Tree @${tree.x},${tree.y} died of old age`, null, { x: tree.x, y: tree.y });
       }
     }

--- a/src/domains/ui/input-handler.ts
+++ b/src/domains/ui/input-handler.ts
@@ -196,6 +196,10 @@ export class InputHandler {
       }
 
       world.selectedId = id || null;
+      world.activeLogAgentId = id || null;
+      // Sync the agent filter dropdown
+      const agentSelect = document.getElementById('agentFilterSelect') as HTMLSelectElement | null;
+      if (agentSelect) agentSelect.value = id || '';
       UIManager.updateInspector(world, dom.inspector);
     });
   }

--- a/src/domains/ui/ui-manager.ts
+++ b/src/domains/ui/ui-manager.ts
@@ -278,6 +278,16 @@ export class UIManager {
     }
   }
 
+  private static _ratePerMinute(timestamps: number[]): number {
+    const now = performance.now();
+    const cutoff = now - 60_000;
+    // Evict old entries
+    while (timestamps.length > 0 && timestamps[0] < cutoff) {
+      timestamps.shift();
+    }
+    return timestamps.length;
+  }
+
   static renderHUD(world: World, _hud: HTMLElement | null, stats: Record<string, unknown>): void {
     const fps = (stats.fps as number) || 0;
     const tAvg = (stats.tickAvg as number) || 0;
@@ -291,8 +301,11 @@ export class UIManager {
     if (s.stFarms) s.stFarms.textContent = String(world.farms.size);
     if (s.stObstacles) s.stObstacles.textContent = String(world.obstacles.size);
     if (s.stFlags) s.stFlags.textContent = String(world.flags.size);
-    if (s.stBirths) s.stBirths.textContent = String(world.totalBirths);
-    if (s.stDeaths) s.stDeaths.textContent = String(world.totalDeaths);
+
+    const birthsPerMin = UIManager._ratePerMinute(world.birthTimestamps);
+    const deathsPerMin = UIManager._ratePerMinute(world.deathTimestamps);
+    if (s.stBirths) s.stBirths.textContent = `${world.totalBirths} (${birthsPerMin}/m)`;
+    if (s.stDeaths) s.stDeaths.textContent = `${world.totalDeaths} (${deathsPerMin}/m)`;
     // Count unique water blocks (large blocks share references across cells)
     const seenWater = new Set<string>();
     for (const wb of world.waterBlocks.values()) seenWater.add(wb.id);
@@ -485,6 +498,16 @@ export class UIManager {
         <div style="color:var(--muted)">ATTACK</div><div>${a.attack.toFixed(1)}</div>
         <div style="color:var(--muted)">XP</div><div>${a.xp} / ${a.xpToNextLevel()}</div>
         <div style="color:var(--muted)">AGE</div><div>${a.ageTicks} ticks</div>
+      </div>
+      <div style="font-size:11px;margin-top:8px;padding:8px;background:rgba(255,255,255,0.03);border-radius:6px;border:1px solid var(--border)">
+        <div style="color:var(--muted);margin-bottom:4px;font-weight:600">MEMORY</div>
+        ${(['food', 'water', 'wood'] as const).map(type => {
+          const entries = a.resourceMemory.get(type) || [];
+          const icon = type === 'food' ? '\u{1F356}' : type === 'water' ? '\u{1F4A7}' : '\u{1FAB5}';
+          return entries.length > 0
+            ? `<div>${icon} ${type}: ${entries.map(e => `(${e.x},${e.y})`).join(' ')}</div>`
+            : `<div style="color:var(--muted)">${icon} ${type}: none</div>`;
+        }).join('')}
       </div>`;
   }
 

--- a/src/domains/world/index.ts
+++ b/src/domains/world/index.ts
@@ -4,3 +4,4 @@ export { WaterField } from './water-field';
 export { LootBagManager } from './loot-bag-manager';
 export { PoopBlockManager } from './poop-block-manager';
 export { World } from './world';
+export type { DeathCause, DeadAgentMarker } from './world';

--- a/src/domains/world/world.ts
+++ b/src/domains/world/world.ts
@@ -7,6 +7,15 @@ import { Grid } from './grid';
 import { FoodField } from './food-field';
 import { WaterField } from './water-field';
 
+export type DeathCause = 'hunger' | 'killed' | 'disease' | 'old_age' | 'tree';
+
+export interface DeadAgentMarker {
+  cellX: number;
+  cellY: number;
+  cause: DeathCause;
+  msRemaining: number;
+}
+
 export class World {
   readonly grid: Grid = new Grid();
   readonly foodField: FoodField = new FoodField();
@@ -23,6 +32,13 @@ export class World {
   tick = 0;
   totalBirths = 0;
   totalDeaths = 0;
+
+  // Death animation markers
+  deadMarkers: DeadAgentMarker[] = [];
+
+  // Birth/death timestamps for per-minute rate tracking
+  birthTimestamps: number[] = [];
+  deathTimestamps: number[] = [];
   speedPct = 100;
   cloudSpawnRate = 1;
   running = false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -206,6 +206,14 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
     }
+
+    // Tick down death markers
+    for (let i = world.deadMarkers.length - 1; i >= 0; i--) {
+      world.deadMarkers[i].msRemaining -= dt;
+      if (world.deadMarkers[i].msRemaining <= 0) {
+        world.deadMarkers.splice(i, 1);
+      }
+    }
     renderer.render(world, ctx, canvas, camera);
     requestAnimationFrame(loop);
   }


### PR DESCRIPTION
## Summary
- **Bug fix:** Fix `seekFromMemory` crash caused by stale array index after `splice()` — stored entry object directly instead of index
- **Death animations:** Agents show 😵 with a cause icon (🦴 hunger, 🩸 killed, 🦠 disease) fading over 3 seconds; trees show 🪾 stump on destruction
- **Inspector memory:** Agent inspection panel now displays remembered resource locations (food, water, wood)
- **Log auto-filter:** Selecting an agent automatically filters the event log to that agent's events
- **Telemetry rates:** Births and deaths HUD entries now show per-minute rolling rate alongside totals

## Test plan
- [ ] Start simulation — verify no `seekFromMemory` crash
- [ ] Watch agents die from hunger, combat, disease — confirm 😵 + correct cause icon appears and fades
- [ ] Deplete a tree or wait for tree old age — confirm 🪾 stump appears and fades
- [ ] Click an agent — verify memory section shows in inspector panel
- [ ] Click an agent — verify event log auto-filters to that agent; click empty space to clear
- [ ] Run simulation for 1+ minutes — verify births/deaths show `(N/m)` rate in telemetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)