### PR TITLE
feat: visual and gameplay improvements (v3.2.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emoji-life",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "private": true,
   "scripts": {
     "build": "esbuild src/main.ts --bundle --outfile=dist/app.js",

--- a/src/domains/action/interaction-engine.ts
+++ b/src/domains/action/interaction-engine.ts
@@ -82,6 +82,42 @@ export class InteractionEngine {
 
     // 7. Normal state (energy >= 40)
 
+    // 7 (early). End-of-life reproduction priority: agents past 80% of max age try to reproduce first
+    if (
+      agent.ageTicks > agent.maxAgeTicks * 0.8 &&
+      agent.fullness >= TUNE.fullness.seekThreshold &&
+      agent.hygiene >= TUNE.hygiene.seekThreshold
+    ) {
+      const eolAdj: [number, number][] = [
+        [agent.cellX + 1, agent.cellY],
+        [agent.cellX - 1, agent.cellY],
+        [agent.cellX, agent.cellY + 1],
+        [agent.cellX, agent.cellY - 1],
+      ];
+      for (const [nx, ny] of eolAdj) {
+        const bid = world.agentsByCell.get(key(nx, ny));
+        if (!bid) continue;
+        const b = world.agentsById.get(bid);
+        if (!b) continue;
+        const rel = agent.relationships.get(b.id);
+        if (
+          rel >= TUNE.reproduction.relationshipThreshold &&
+          agent.energy >= TUNE.reproduction.relationshipEnergy &&
+          b.energy >= TUNE.reproduction.relationshipEnergy &&
+          !agent.diseased && !b.diseased
+        ) {
+          if (ActionFactory.tryStart(agent, 'reproduce', { targetId: b.id })) {
+            const dur = agent.action!.remainingMs;
+            agent.drainEnergy(4);
+            b.drainEnergy(4);
+            lockAgent(world, agent.id, dur);
+            lockAgent(world, b.id, dur);
+            return;
+          }
+        }
+      }
+    }
+
     // 7a. Proactive food seeking
     if (agent.fullness < TUNE.fullness.seekThreshold) {
       if (agent.inventory.food > 0) {

--- a/src/domains/rendering/renderer.ts
+++ b/src/domains/rendering/renderer.ts
@@ -41,6 +41,7 @@ export class Renderer {
     this._drawAgents(ctx, world, pendingAttackLines);
     this._drawDeadMarkers(ctx, world);
     this._drawAttackLines(ctx, camera, pendingAttackLines);
+    this._drawSelectedAgentPath(ctx, world);
 
     this._drawClouds(ctx, world, camera);
 
@@ -94,14 +95,20 @@ export class Renderer {
     for (const tree of world.treeBlocks.values()) {
       const pct = tree.units / tree.maxUnits;
       ctx.globalAlpha = 0.4 + 0.6 * pct;
+      let nearWater = false;
+      for (const wb of world.waterBlocks.values()) {
+        if (Math.abs(tree.x - wb.x) + Math.abs(tree.y - wb.y) <= 5) { nearWater = true; break; }
+      }
+      if (!nearWater) ctx.filter = 'saturate(0.2)';
       this._drawCellEmoji(ctx, tree.x, tree.y, tree.emoji);
+      ctx.filter = 'none';
       ctx.globalAlpha = 1;
     }
   }
 
   private _drawSeedlings(ctx: CanvasRenderingContext2D, world: World): void {
     for (const s of world.seedlings.values()) {
-      this._drawCellEmoji(ctx, s.x, s.y, WORLD_EMOJIS.seedling);
+      this._drawCellEmoji(ctx, s.x, s.y, WORLD_EMOJIS.seedling, CELL / 2);
     }
   }
 
@@ -115,7 +122,7 @@ export class Renderer {
     for (const poop of world.poopBlocks.values()) {
       const fadeRatio = Math.max(0.3, poop.decayMs / TUNE.poop.decayMs);
       ctx.globalAlpha = fadeRatio;
-      this._drawCellEmoji(ctx, poop.x, poop.y, WORLD_EMOJIS.poop);
+      this._drawCellEmoji(ctx, poop.x, poop.y, WORLD_EMOJIS.poop, CELL / 2);
       ctx.globalAlpha = 1;
     }
   }
@@ -124,7 +131,7 @@ export class Renderer {
     for (const fb of world.foodBlocks.values()) {
       const pct = fb.units / fb.maxUnits;
       ctx.globalAlpha = 0.4 + 0.6 * pct;
-      this._drawCellEmoji(ctx, fb.x, fb.y, fb.emoji || FOOD_EMOJIS.lq[0]);
+      this._drawCellEmoji(ctx, fb.x, fb.y, fb.emoji || FOOD_EMOJIS.lq[0], CELL / 2);
       ctx.globalAlpha = 1;
     }
   }
@@ -144,10 +151,25 @@ export class Renderer {
   }
 
   private _drawObstacles(ctx: CanvasRenderingContext2D, world: World): void {
+    const drawn = new Set<string>();
     for (const o of world.obstacles.values()) {
+      if (drawn.has(o.id)) continue;
+      drawn.add(o.id);
       const dmg = 1 - o.hp / o.maxHp;
       ctx.globalAlpha = dmg > 0 ? 1 - Math.min(0.7, dmg) : 1;
-      this._drawCellEmoji(ctx, o.x, o.y, o.emoji);
+      if (o.size === '2x2') {
+        // Draw one large emoji centered on the 2x2 block
+        const { canvas: ec, w, h } = this._emojiCache.get(o.emoji);
+        const drawSize = CELL * 2 - 2;
+        const scale = Math.min(drawSize / w, drawSize / h);
+        const dw = w * scale;
+        const dh = h * scale;
+        const bx = o.x * CELL;
+        const by = o.y * CELL;
+        ctx.drawImage(ec, bx + (CELL * 2 - dw) / 2, by + (CELL * 2 - dh) / 2, dw, dh);
+      } else {
+        this._drawCellEmoji(ctx, o.x, o.y, o.emoji);
+      }
       ctx.globalAlpha = 1;
     }
   }
@@ -275,10 +297,14 @@ export class Renderer {
     }
   }
 
-  private _drawAttackLines(ctx: CanvasRenderingContext2D, camera: Camera, lines: [Agent, Agent][]): void {
-    ctx.strokeStyle = COLORS.attackLine;
-    ctx.globalAlpha = 0.7;
-    ctx.lineWidth = 1 / camera.scale;
+  private _drawAttackLines(ctx: CanvasRenderingContext2D, _camera: Camera, lines: [Agent, Agent][]): void {
+    const daggerEmoji = '\uD83D\uDDE1\uFE0F'; // 🗡️
+    const { canvas: ec, w, h } = this._emojiCache.get(daggerEmoji);
+    const daggerSize = CELL - 2;
+    const scale = Math.min(daggerSize / w, daggerSize / h);
+    const dw = w * scale;
+    const dh = h * scale;
+
     for (const [att, tgt] of lines) {
       const at = att.lerpT != null ? att.lerpT : 1;
       const ax = ((att.prevCellX ?? att.cellX) + (att.cellX - (att.prevCellX ?? att.cellX)) * at) * CELL + CELL / 2;
@@ -286,12 +312,19 @@ export class Renderer {
       const tt = tgt.lerpT != null ? tgt.lerpT : 1;
       const tx = ((tgt.prevCellX ?? tgt.cellX) + (tgt.cellX - (tgt.prevCellX ?? tgt.cellX)) * tt) * CELL + CELL / 2;
       const ty = ((tgt.prevCellY ?? tgt.cellY) + (tgt.cellY - (tgt.prevCellY ?? tgt.cellY)) * tt) * CELL + CELL / 2;
-      ctx.beginPath();
-      ctx.moveTo(ax, ay);
-      ctx.lineTo(tx, ty);
-      ctx.stroke();
+
+      const mx = (ax + tx) / 2;
+      const my = (ay + ty) / 2;
+      // Angle from attacker toward target; 🗡️ naturally points up-right (~-45°), offset accordingly
+      const angle = Math.atan2(ty - ay, tx - ax) + Math.PI * 1.25;
+
+      ctx.save();
+      ctx.globalAlpha = 0.9;
+      ctx.translate(mx, my);
+      ctx.rotate(angle);
+      ctx.drawImage(ec, -dw / 2, -dh / 2, dw, dh);
+      ctx.restore();
     }
-    ctx.globalAlpha = 1;
   }
 
   private _drawClouds(ctx: CanvasRenderingContext2D, world: World, _camera: Camera): void {
@@ -299,6 +332,44 @@ export class Renderer {
       const fadeRatio = Math.max(0, cloud.lifetimeMs / 5000);
       ctx.globalAlpha = Math.min(0.7, fadeRatio);
       this._drawCellEmoji(ctx, cloud.x, cloud.y, WORLD_EMOJIS.cloud, CELL * 2);
+      ctx.globalAlpha = Math.min(0.45, fadeRatio * 0.65);
+      this._drawCellEmoji(ctx, cloud.x - 1, cloud.y, WORLD_EMOJIS.cloud, CELL * 1.6);
+      this._drawCellEmoji(ctx, cloud.x + 1, cloud.y - 1, WORLD_EMOJIS.cloud, CELL * 1.6);
+      ctx.globalAlpha = 1;
+    }
+  }
+
+  private _drawSelectedAgentPath(ctx: CanvasRenderingContext2D, world: World): void {
+    if (!world.selectedId) return;
+    const agent = world.agentsById.get(world.selectedId);
+    if (!agent || !agent.path || agent.path.length === 0) return;
+    const remaining = agent.path.slice(agent.pathIdx);
+    if (remaining.length === 0) return;
+
+    const t = agent.lerpT != null ? agent.lerpT : 1;
+    const px = agent.prevCellX != null ? agent.prevCellX : agent.cellX;
+    const py = agent.prevCellY != null ? agent.prevCellY : agent.cellY;
+    const lx = px + (agent.cellX - px) * t;
+    const ly = py + (agent.cellY - py) * t;
+
+    ctx.save();
+    ctx.strokeStyle = '#ff4444';
+    ctx.lineWidth = 1.5;
+    ctx.globalAlpha = 0.65;
+    ctx.setLineDash([3, 3]);
+    ctx.beginPath();
+    ctx.moveTo(lx * CELL + CELL / 2, ly * CELL + CELL / 2);
+    for (const pos of remaining) {
+      ctx.lineTo(pos.x * CELL + CELL / 2, pos.y * CELL + CELL / 2);
+    }
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.restore();
+
+    const goalPos = agent.goal ?? remaining[remaining.length - 1];
+    if (goalPos) {
+      ctx.globalAlpha = 0.9;
+      this._drawCellEmoji(ctx, goalPos.x, goalPos.y, '\uD83D\uDCCD', CELL - 2);
       ctx.globalAlpha = 1;
     }
   }

--- a/src/domains/ui/controls.ts
+++ b/src/domains/ui/controls.ts
@@ -14,12 +14,37 @@ function seedEnvironment(world: World): void {
     const y = rndi(5, GRID - 6);
     world.farms.set(key(x, y), { id: uuid(), x, y });
   }
-  // Scatter random obstacles
-  const obstacleCount = rndi(15, 30);
+  // Scatter random obstacles — mix of 1x1 and 2x2
+  const obstacleCount = rndi(30, 50);
   for (let i = 0; i < obstacleCount; i++) {
-    const { x, y } = world.grid.randomFreeCell();
     const emoji = OBSTACLE_EMOJIS[Math.floor(Math.random() * OBSTACLE_EMOJIS.length)];
-    world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji, hp: 12, maxHp: 12 });
+    if (Math.random() < 0.4) {
+      // Try 2x2 placement — one shared obstacle object across all 4 cells
+      let placed = false;
+      for (let attempt = 0; attempt < 50; attempt++) {
+        const x = rndi(1, GRID - 3);
+        const y = rndi(1, GRID - 3);
+        if (!world.grid.isCellOccupied(x, y) &&
+            !world.grid.isCellOccupied(x + 1, y) &&
+            !world.grid.isCellOccupied(x, y + 1) &&
+            !world.grid.isCellOccupied(x + 1, y + 1)) {
+          const obs = { id: uuid(), x, y, emoji, hp: 24, maxHp: 24, size: '2x2' as const };
+          world.obstacles.set(key(x, y),         obs);
+          world.obstacles.set(key(x + 1, y),     obs);
+          world.obstacles.set(key(x, y + 1),     obs);
+          world.obstacles.set(key(x + 1, y + 1), obs);
+          placed = true;
+          break;
+        }
+      }
+      if (!placed) {
+        const { x, y } = world.grid.randomFreeCell();
+        world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji, hp: 12, maxHp: 12 });
+      }
+    } else {
+      const { x, y } = world.grid.randomFreeCell();
+      world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji, hp: 12, maxHp: 12 });
+    }
   }
   SimulationEngine.seedInitialTrees(world, rndi(8, 15));
   SimulationEngine.seedInitialWater(world, rndi(3, 6));

--- a/src/domains/ui/ui-manager.ts
+++ b/src/domains/ui/ui-manager.ts
@@ -471,7 +471,7 @@ export class UIManager {
             <span>${a.social.toFixed(1)}/100</span>
           </div>
           <div class="agent-stat-bar">
-            <div class="agent-stat-fill" style="background:#fb923c;width:${a.social}%"></div>
+            <div class="agent-stat-fill" style="background:#f472b6;width:${a.social}%"></div>
           </div>
         </div>
         <div>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -87,7 +87,7 @@ export const TUNE = {
     perShare: 5,
     perBuildFarm: 15,
     perHarvest: 2,
-    perLevel: 50,
+    perLevel: 25,
   },
   maxEnergyBase: 200,
   maxEnergyPerLevel: 5,
@@ -151,7 +151,7 @@ export const TUNE = {
   cloud: {
     spawnIntervalRange: [60000, 120000] as [number, number],
     lifetimeRange: [5000, 10000] as [number, number],
-    smallChance: 0.9,
+    smallChance: 0.5,
     targetWaterCoverage: 0.05,
   },
   hygiene: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -100,6 +100,7 @@ export interface IObstacle {
   emoji: string;
   hp: number;
   maxHp: number;
+  size?: '2x2';
 }
 
 export interface IFlagStorage {


### PR DESCRIPTION
## Summary

- **Passable blocks smaller** — food, poop, and seedlings render at half cell size (CELL/2) so they're less visually dominant
- **Tree desaturation** — trees more than 5 cells from any water block render at 20% saturation, hinting they can't spawn seedlings or food
- **2×2 obstacles** — 40% of spawned obstacles use a single emoji spanning a 2×2 block; spawn count increased to 30–50
- **🗡️ attack indicator** — replaces the red line with a dagger emoji rotated tip-first toward the target
- **Richer clouds** — each cloud renders as a cluster of 3 emojis; rain has a 50/50 chance of large vs small water block (was 10%)
- **Path visualization** — selecting a moving agent shows their planned path as a dashed red line with 📍 at the destination
- **End-of-life reproduction** — agents past 80% of max age skip the normal queue and attempt reproduction first (if needs met)
- **Faster leveling** — XP required per level halved (50 → 25)
- **Need bar colors** — social bar changed to pink, making all 6 need bars visually distinct

## Test plan

- [ ] Start a new simulation and verify 2×2 obstacle blocks appear (single large emoji over 4 cells)
- [ ] Confirm food, poop, and seedling emojis are noticeably smaller than agents/trees
- [ ] Verify trees near water are fully saturated; trees far from water appear washed out
- [ ] Trigger an attack and confirm 🗡️ appears pointing toward the target
- [ ] Spawn a cloud manually and verify a cluster of cloud emojis appears
- [ ] Select a moving agent and confirm dashed path + 📍 renders
- [ ] Let an agent reach old age and observe reproduction attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)