### PR TITLE
fix: agents wander when global pathfind to food/water fails

### DIFF
--- a/src/domains/simulation/simulation-engine.ts
+++ b/src/domains/simulation/simulation-engine.ts
@@ -646,7 +646,7 @@ export class SimulationEngine {
       const near = Pathfinder.findNearest(agent, filtered);
       if (near) {
         Pathfinder.planPathTo(world, agent, near.target.x, near.target.y);
-        return;
+        if (agent.path && agent.path.length > 0) return;
       }
     }
 
@@ -773,7 +773,7 @@ export class SimulationEngine {
       const near = Pathfinder.findNearest(agent, waterPositions);
       if (near) {
         Pathfinder.planPathTo(world, agent, near.target.x, near.target.y);
-        return;
+        if (agent.path && agent.path.length > 0) return;
       }
     }
 


### PR DESCRIPTION
## Summary
- Agents could starve standing still when food existed on the map but was unreachable (blocked by terrain/water)
- The global pathfind step in `seekFoodWhenHungry` and `seekWaterWhenThirsty` returned unconditionally after calling `planPathTo`, skipping the wander fallback even when no valid path was created
- Now checks `agent.path && agent.path.length > 0` before returning, matching the pattern already used in the vision-range search step

## Test plan
- [ ] Spawn an agent surrounded by terrain with no reachable food — verify it wanders instead of standing still
- [ ] Verify agents still pathfind correctly to reachable food/water
- [ ] Verify agents eventually find food through wandering when blocked paths clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)