### PR TITLE
feat: Greed trait, path give-up, terrain fix, social memory sharing, misc fixes

### DIFF
--- a/src/domains/action/effects/social-effects.ts
+++ b/src/domains/action/effects/social-effects.ts
@@ -1,11 +1,12 @@
 import { log } from '../../../core/utils';
-import type { IInventory } from '../../../core/types';
+import type { IInventory, ResourceMemoryType } from '../../../core/types';
 import type { Agent } from '../../entity/agent';
 import type { World } from '../../world/world';
 import { FactionManager } from '../../faction/faction-manager';
 
 // ── Constants (was TUNE) ──
 const HYGIENE_SOCIAL_DECAY = 0.5;
+const MEMORY_SHARE_REL_THRESHOLD = 0.5;
 const XP_PER_HEAL = 10;
 const XP_PER_SHARE = 5;
 const SHARE_SOCIAL_SHARER = 8;
@@ -29,6 +30,7 @@ export function onTalkTick(world: World, agent: Agent, target: Agent): void {
 export function onTalkComplete(world: World, agent: Agent, target: Agent): void {
   applySocialHygieneDecay(agent, target);
   maybeFormFaction(world, agent, target);
+  shareResourceMemories(agent, target, world.tick);
 }
 
 // ── Quarrel ──
@@ -85,6 +87,7 @@ export function onShareComplete(world: World, agent: Agent, target: Agent): void
   applySocialHygieneDecay(agent, target);
   checkLevelUp(world, agent);
   maybeFormFaction(world, agent, target);
+  shareResourceMemories(agent, target, world.tick);
 
   // Faction recruitment via share
   if (agent.factionId) {
@@ -123,6 +126,30 @@ function pickShareResource(agent: Agent, target: Agent): keyof IInventory | null
   if (water >= food && water >= wood && water > 0) return 'water';
   if (wood > 0) return 'wood';
   return null;
+}
+
+/**
+ * If the two agents have a strong enough relationship, exchange resource memories.
+ * Snapshots are taken before writing so neither agent's entries are mutated mid-iteration.
+ * Shared entries use the current tick so they are treated as freshly discovered —
+ * rememberResource will evict the oldest entry when a slot limit is reached.
+ */
+function shareResourceMemories(agent: Agent, target: Agent, currentTick: number): void {
+  const rel = agent.relationships.get(target.id);
+  if (rel < MEMORY_SHARE_REL_THRESHOLD) return;
+
+  const types: ResourceMemoryType[] = ['food', 'water', 'wood'];
+  for (const type of types) {
+    const agentEntries = [...agent.resourceMemory.get(type)!];
+    const targetEntries = [...target.resourceMemory.get(type)!];
+
+    for (const e of agentEntries) {
+      target.rememberResource(type, e.x, e.y, currentTick);
+    }
+    for (const e of targetEntries) {
+      agent.rememberResource(type, e.x, e.y, currentTick);
+    }
+  }
 }
 
 function checkLevelUp(world: World, agent: Agent): void {

--- a/src/domains/decision/decision-engine.ts
+++ b/src/domains/decision/decision-engine.ts
@@ -41,6 +41,7 @@ export class DecisionEngine {
         actionType,
         targetId: target?.targetId,
         targetPos: target?.targetPos,
+        resourceType: (target as { resourceType?: string } | null)?.resourceType,
         score,
       });
     }

--- a/src/domains/decision/types.ts
+++ b/src/domains/decision/types.ts
@@ -40,5 +40,6 @@ export interface ActionCandidate {
   readonly actionType: ActionType;
   readonly targetId?: string;
   readonly targetPos?: IPosition;
+  readonly resourceType?: string;
   readonly score: number;
 }

--- a/src/domains/entity/agent.ts
+++ b/src/domains/entity/agent.ts
@@ -54,6 +54,9 @@ export class Agent {
   // Lineage
   generation: number;
 
+  // Navigation
+  pathFailCount: number;
+
   // Legacy fields
   poopTimerMs: number;
   babyMsRemaining: number;
@@ -129,6 +132,9 @@ export class Agent {
 
     // Lineage
     this.generation = opts.generation ?? 1;
+
+    // Navigation
+    this.pathFailCount = 0;
 
     // Legacy
     this.poopTimerMs = opts.poopTimerMs ?? 0;

--- a/src/domains/entity/family-registry.ts
+++ b/src/domains/entity/family-registry.ts
@@ -33,6 +33,7 @@ export class FamilyRegistry {
 
   getAllFamilies(): FamilyStats[] {
     return Array.from(this.families.values())
+      .filter(f => f.currentlyAlive > 0)
       .sort((a, b) => b.currentlyAlive - a.currentlyAlive);
   }
 

--- a/src/domains/genetics/expression.ts
+++ b/src/domains/genetics/expression.ts
@@ -63,6 +63,7 @@ export function expressGenome(genes: ReadonlyArray<RawGeneEntry>): TraitSet {
   const maturity = s('QQ');
   const endurance = s('RR');
   const fidelity = s('SS');
+  const greed = s('UU');
 
   // Parthenogenesis is special: boolean based on raw > 0
   const partRaw = rawSums.get('TT') ?? 0;
@@ -133,6 +134,9 @@ export function expressGenome(genes: ReadonlyArray<RawGeneEntry>): TraitSet {
     },
     fidelity: {
       leaveProbability: fidelity['leaveProbability'] ?? 0.5,
+    },
+    greed: {
+      hoardProbability: greed['hoardProbability'] ?? 0.4,
     },
   };
 }

--- a/src/domains/genetics/gene-registry.ts
+++ b/src/domains/genetics/gene-registry.ts
@@ -18,7 +18,7 @@ export const GENE_REGISTRY: ReadonlyMap<string, TraitDef> = new Map<string, Trai
   ['BB', {
     code: 'BB', name: 'Longevity', essential: true,
     components: [
-      { key: 'maxAgeMs', min: 120000, default: 300000, max: 600000, scale: 0.5, inverted: false },
+      { key: 'maxAgeMs', min: 120000, default: 300000, max: 600000, scale: 0.005, inverted: false },
     ],
   }],
   ['CC', {
@@ -133,6 +133,12 @@ export const GENE_REGISTRY: ReadonlyMap<string, TraitDef> = new Map<string, Trai
     components: [
       // Special: expressed as boolean (rawValue > 0 = true)
       { key: 'canSelfReproduce', min: 0, default: 0, max: 1, scale: 1, inverted: false },
+    ],
+  }],
+  ['UU', {
+    code: 'UU', name: 'Greed', essential: false,
+    components: [
+      { key: 'hoardProbability', min: 0.0, default: 0.4, max: 1.0, scale: 500, inverted: false },
     ],
   }],
 ]);

--- a/src/domains/genetics/types.ts
+++ b/src/domains/genetics/types.ts
@@ -35,6 +35,7 @@ export interface TraitSet {
   readonly maturity: { readonly babyDurationMs: number };
   readonly endurance: { readonly inventoryCapacity: number };
   readonly fidelity: { readonly leaveProbability: number };
+  readonly greed: { readonly hoardProbability: number };
 }
 
 /** Definition of a single trait component's scaling */

--- a/src/domains/rendering/camera.ts
+++ b/src/domains/rendering/camera.ts
@@ -37,6 +37,16 @@ export class Camera implements ICameraState {
     this.y = yMin < yMax ? clamp(this.y, yMin, yMax) : (WORLD_PX - vh / this.scale) / 2;
   }
 
+  centerOn(cellX: number, cellY: number, cellPx: number): void {
+    const wx = cellX * cellPx;
+    const wy = cellY * cellPx;
+    const vw = this.viewW || window.innerWidth;
+    const vh = this.viewH || window.innerHeight;
+    this.x = wx - vw / (2 * this.scale);
+    this.y = wy - vh / (2 * this.scale);
+    this.panBy(0, 0); // clamp to valid bounds
+  }
+
   fitToCanvas(canvas: HTMLCanvasElement): void {
     this.scale = clamp(
       Math.min(canvas.width / WORLD_PX, canvas.height / WORLD_PX),

--- a/src/domains/rendering/renderer.ts
+++ b/src/domains/rendering/renderer.ts
@@ -139,7 +139,7 @@ export class Renderer {
 
   private _rebuildTerrainCache(world: World): void {
     const size = GRID_SIZE * CELL_PX;
-    if (!this._terrainCanvas) {
+    if (!this._terrainCanvas || this._terrainCanvas.width !== size) {
       this._terrainCanvas = document.createElement('canvas');
       this._terrainCanvas.width = size;
       this._terrainCanvas.height = size;

--- a/src/domains/simulation/agent-updater.ts
+++ b/src/domains/simulation/agent-updater.ts
@@ -28,7 +28,7 @@ const HYGIENE_STEP_ON_POOP_DECAY = 5;
 
 const FULLNESS_SEEK_THRESHOLD = 40;
 const FULLNESS_CRITICAL_THRESHOLD = 20;
-const FULLNESS_REGEN_THRESHOLD = 70;
+const FULLNESS_REGEN_THRESHOLD = 60;
 const HYGIENE_SEEK_THRESHOLD = 40;
 const INSPIRATION_SEEK_THRESHOLD = 40;
 
@@ -43,6 +43,7 @@ const DISEASE_CONTRACTION_THRESHOLD = 20;
 const DISEASE_CONTRACTION_CHANCE = 0.05;
 
 const VISION_RANGE = 10;
+const PATH_GIVE_UP_ATTEMPTS = 4;
 
 const FARM_WOOD_COST = 3;
 const FARM_ENERGY_COST = 6;
@@ -79,6 +80,12 @@ function agentPlanPath(world: World, agent: Agent, gx: number, gy: number): void
     world._pathWhitelist
   );
   world.pathBudget = budget.remaining;
+
+  if (!agent.path || agent.path.length === 0) {
+    agent.pathFailCount++;
+  } else {
+    agent.pathFailCount = 0;
+  }
 }
 
 // ── Inline ActionFactory.tryStart (old API compat) ──
@@ -351,7 +358,16 @@ function seekFoodWhenHungry(world: World, agent: Agent): void {
   }
 
   // 4. Resource memory
-  if (seekFromMemory(world, agent, 'food')) return;
+  if (seekFromMemory(world, agent, 'food')) {
+    if (agent.pathFailCount >= PATH_GIVE_UP_ATTEMPTS) {
+      // Can't reach any remembered food — clear food memory and wander
+      agent.resourceMemory.set('food', []);
+      agent.pathFailCount = 0;
+      biasedRoam(world, agent);
+      return;
+    }
+    return;
+  }
 
   // 5. Full pathfind (global)
   if (world.tick - world.foodField.lastTick >= 5) {
@@ -439,7 +455,15 @@ function seekWaterWhenThirsty(world: World, agent: Agent): void {
   }
 
   // 4. Resource memory
-  if (seekFromMemory(world, agent, 'water')) return;
+  if (seekFromMemory(world, agent, 'water')) {
+    if (agent.pathFailCount >= PATH_GIVE_UP_ATTEMPTS) {
+      agent.resourceMemory.set('water', []);
+      agent.pathFailCount = 0;
+      biasedRoam(world, agent);
+      return;
+    }
+    return;
+  }
 
   // 5. Full pathfind (global)
   if (world.tick - world.waterField.lastTick >= 5) {
@@ -553,6 +577,10 @@ export class AgentUpdater {
     // Baby timer
     if (agent.babyMsRemaining > 0) {
       agent.babyMsRemaining = Math.max(0, agent.babyMsRemaining - TICK_MS);
+      if (agent.babyMsRemaining === 0 && agent.entityClass === 'baby') {
+        agent.entityClass = 'adult';
+        log(world, 'spawn', `${agent.name} grew up`, agent.id, {});
+      }
     }
 
     // Pregnancy timer
@@ -804,11 +832,12 @@ export class AgentUpdater {
                 }
 
                 if (!agent.action) {
-                  // Opportunistic food/wood harvest
-                  if (!agent.inventoryFull() && Math.random() < 0.4) {
+                  // Opportunistic food/wood harvest (scaled by Greed trait)
+                  const greedP = agent.traits.greed.hoardProbability;
+                  if (!agent.inventoryFull() && Math.random() < greedP) {
                     tryHarvestAdjacentFood(world, agent);
                   }
-                  if (!agent.action && !agent.inventoryFull() && Math.random() < 0.3) {
+                  if (!agent.action && !agent.inventoryFull() && Math.random() < greedP * 0.75) {
                     tryHarvestAdjacentWood(world, agent);
                   }
                   if (!agent.action) {

--- a/src/domains/simulation/agent-updater.ts
+++ b/src/domains/simulation/agent-updater.ts
@@ -716,7 +716,7 @@ export class AgentUpdater {
               tryStartAction(agent,candidate.actionType, { targetId: candidate.targetId });
             } else if (candidate.targetPos) {
               if (candidate.actionType === 'harvest') {
-                const resourceType = (candidate as { resourceType?: string }).resourceType ?? 'food_lq';
+                const resourceType = candidate.resourceType ?? 'food_lq';
                 createHarvestAction(agent, resourceType, candidate.targetPos);
               } else {
                 tryStartAction(agent,candidate.actionType, { targetPos: candidate.targetPos });

--- a/src/domains/ui/controls.ts
+++ b/src/domains/ui/controls.ts
@@ -138,6 +138,7 @@ export class Controls {
       const worldSize = Number(ranges.rngWorldSize?.value || 62);
       setGridSize(worldSize);
       world.grid.size = worldSize;
+      world.terrainField.resize(worldSize);
 
       world.speedPct = Number(ranges.rngSpeed?.value || 100);
       world.cloudSpawnRate = Number(ranges.rngCloudRate?.value || 1);

--- a/src/domains/ui/ui-manager.ts
+++ b/src/domains/ui/ui-manager.ts
@@ -525,7 +525,7 @@ export class UIManager {
         <div class="agent-avatar">${emoji}</div>
         <div class="agent-info">
           <div class="agent-name-row">
-            <span class="agent-name">${a.name} ${a.familyName !== a.name ? a.familyName : ''}</span>
+            <span class="agent-name" data-action="center-agent" title="Click to pan to agent" style="cursor:pointer;text-decoration:underline dotted">${a.name} ${a.familyName !== a.name ? a.familyName : ''}</span>
             <span class="agent-level">LV. ${String(a.level).padStart(2, '0')}</span>
           </div>
           <div class="agent-badges">
@@ -643,6 +643,7 @@ export class UIManager {
           ${traitCell('CHR', a.traits.charisma.relationshipSlots.toFixed(0), a.traits.charisma.relationshipSlots, 'NN', 'Charisma — Max relationship slots')}
           ${traitCell('END', a.traits.endurance.inventoryCapacity.toFixed(0), a.traits.endurance.inventoryCapacity, 'RR', 'Endurance — Inventory capacity')}
           ${traitCell('MAT', (a.traits.maturity.babyDurationMs / 1000).toFixed(0) + 's', a.traits.maturity.babyDurationMs, 'QQ', 'Maturity — Baby stage duration (lower = matures faster)')}
+          ${traitCell('GRD', a.traits.greed.hoardProbability.toFixed(2), a.traits.greed.hoardProbability, 'UU', 'Greed — Probability of opportunistic resource hoarding')}
           ${a.traits.parthenogenesis.canSelfReproduce ? '<div title="Parthenogenesis — Can reproduce without a partner" style="color:#f9a8d4;cursor:help">ASEXUAL</div>' : ''}
         </div>
       </div>

--- a/src/domains/world/terrain-field.ts
+++ b/src/domains/world/terrain-field.ts
@@ -2,16 +2,14 @@ import { GRID_SIZE } from '../../core/constants';
 import { manhattan } from '../../core/utils';
 import type { Grid } from './grid';
 
-const tfIdx = (x: number, y: number): number => y * GRID_SIZE + x;
-
 /** Per-frame step size for display moisture lerp (higher = faster transition). */
 const LERP_STEP = 3;
 
 export class TerrainField {
   /** Target moisture per cell: 0 = dry, 127 = neutral, 255 = wet. Set by recomputeAll(). */
-  readonly moisture: Uint8Array;
+  moisture: Uint8Array;
   /** Display moisture — what the renderer actually draws. Lerps toward `moisture` each frame. */
-  readonly displayMoisture: Uint8Array;
+  displayMoisture: Uint8Array;
   /** Incremented whenever display values change — used by the renderer to invalidate its terrain cache. */
   version = 0;
   /** True while displayMoisture is still converging toward moisture. */
@@ -21,6 +19,15 @@ export class TerrainField {
     const N = GRID_SIZE * GRID_SIZE;
     this.moisture = new Uint8Array(N);
     this.displayMoisture = new Uint8Array(N);
+  }
+
+  /** Reallocate arrays for a new grid size. Call this whenever GRID_SIZE changes. */
+  resize(size: number): void {
+    const N = size * size;
+    this.moisture = new Uint8Array(N);
+    this.displayMoisture = new Uint8Array(N);
+    this.version++;
+    this.transitioning = false;
   }
 
   /** Full recompute of all cell moisture values based on water proximity. */
@@ -39,7 +46,7 @@ export class TerrainField {
 
     for (let y = 0; y < GRID_SIZE; y++) {
       for (let x = 0; x < GRID_SIZE; x++) {
-        const i = tfIdx(x, y);
+        const i = y * GRID_SIZE + x;
 
         if (grid.saltWaterBlocks.has(`${x},${y}`)) {
           this.moisture[i] = 0;
@@ -109,6 +116,6 @@ export class TerrainField {
 
   moistureAt(x: number, y: number): number {
     if (x < 0 || y < 0 || x >= GRID_SIZE || y >= GRID_SIZE) return 0;
-    return this.displayMoisture[tfIdx(x, y)];
+    return this.displayMoisture[y * GRID_SIZE + x];
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
-import { TICK_MS } from './core/constants';
+import { TICK_MS, CELL_PX } from './core/constants';
 
-const VERSION = '4.0.0';
+const VERSION = '4.1.0';
 import { World } from './domains/world';
 import { Camera } from './domains/rendering/camera';
 import { Renderer } from './domains/rendering/renderer';
@@ -74,6 +74,17 @@ document.addEventListener('DOMContentLoaded', () => {
     dom.familySortEl.addEventListener('change', () => {
       world.familySort = dom.familySortEl!.value as 'alive' | 'total' | 'name' | 'lifespan' | 'generation';
       UIManager._lastFamiliesSig = ''; // force rebuild
+    });
+  }
+
+  // Click agent name in inspector → center camera
+  if (dom.inspector) {
+    dom.inspector.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement;
+      if (target.dataset['action'] === 'center-agent' && world.selectedId) {
+        const agent = world.agentsById.get(world.selectedId);
+        if (agent) camera.centerOn(agent.cellX, agent.cellY, CELL_PX);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

- **Greed trait (UU gene)**: new genetic trait \`hoardProbability\` (0.0–1.0) that controls how aggressively agents opportunistically harvest food/wood when not actively hungry. Shown in inspector as \`GRD\`.
- **Baby → adult promotion**: \`entityClass\` was never updated when \`babyMsRemaining\` expired. Now correctly promotes to \`'adult'\` and logs a "grew up" event.
- **Path give-up**: agents track consecutive path planning failures (\`pathFailCount\`). After 4 failures on a food/water memory target they clear that resource memory and wander instead of looping on an unreachable block.
- **Terrain rendering fix**: when a non-default world size is selected, \`TerrainField\` moisture arrays were still sized at 62×62 and the renderer's terrain canvas was never recreated. Added \`TerrainField.resize()\` called alongside \`setGridSize()\`, and the renderer now recreates the canvas when dimensions change.
- **Vitality regen fix**: \`FULLNESS_REGEN_THRESHOLD\` lowered from 70 → 60 so agents in normal fullness range regenerate health.
- **Families panel**: extinct families (0 alive) are now filtered out.
- **BB Longevity scale fix**: scale corrected from \`0.5\` → \`0.005\`. Agents now show meaningful lifespan variation (120s–600s) instead of clustering at the 300s default.
- **Click-to-center**: clicking an agent's name in the inspector pans the camera to center on them.
- **Social memory sharing**: agents with relationship ≥ 0.5 exchange all resource memories on \`talk\` and \`share\` completion. Snapshots taken before writing; oldest entries evicted first via the existing \`rememberResource\` slot logic.
- **Fix: harvest resourceType dropped by DecisionEngine**: \`resolveTarget()\` returned \`resourceType\` for harvest candidates but \`decide()\` only spread \`targetId\` and \`targetPos\` into \`ActionCandidate\` — \`resourceType\` was silently lost. Water and wood harvests always fell back to \`food_lq\`, found no food block at the target cell, and left inventory unchanged while the resource persisted, causing agents to loop harvesting the same block forever with no result. Fixed by adding \`resourceType\` to \`ActionCandidate\` and threading it through.
- **Version bump**: \`main.ts\` version constant updated to \`4.1.0\`.

## Test plan

- [ ] Start sim with non-default world size — terrain should fill the full grid
- [ ] Inspect agents — lifespans should vary from ~2 to ~10 minutes
- [ ] Let a baby hatch/be born — confirm BABY badge disappears and agent starts acting as adult
- [ ] Block access to a food source — agent should give up and wander after a few attempts instead of spinning
- [ ] Inspect two long-standing faction mates — confirm they share resource memory entries
- [ ] Let a family go extinct — confirm it disappears from the Families panel
- [ ] Click an agent name in the inspector — camera should pan to that agent
- [ ] Watch agents near water/trees — confirm inventory gains water/wood after harvesting

🤖 Generated with [Claude Code](https://claude.com/claude-code)