### PR TITLE
fix: deposit/withdraw resourceType lost through DecisionEngine

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emoji-life",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "private": true,
   "scripts": {
     "build": "esbuild src/main.ts --bundle --outfile=dist/app.js",

--- a/src/domains/decision/decision-engine.ts
+++ b/src/domains/decision/decision-engine.ts
@@ -204,6 +204,17 @@ function resolveTarget(
       if (!trees.length) return null;
       return { targetPos: { x: trees[0].pos.x, y: trees[0].pos.y } };
     }
+    case 'deposit': {
+      const { food, water, wood } = agent.inventory;
+      if (food + water + wood <= 0) return null;
+      const rt = food >= water && food >= wood ? 'food'
+        : water >= wood ? 'water' : 'wood';
+      return { resourceType: rt } as { resourceType: string } & { targetId?: string; targetPos?: { x: number; y: number } };
+    }
+    case 'withdraw': {
+      const rt = agent.fullness <= agent.hygiene ? 'food' : 'water';
+      return { resourceType: rt } as { resourceType: string } & { targetId?: string; targetPos?: { x: number; y: number } };
+    }
     default:
       return {};
   }

--- a/src/domains/persistence/persistence-manager.ts
+++ b/src/domains/persistence/persistence-manager.ts
@@ -6,7 +6,7 @@ import { Agent } from '../entity/agent';
 import { Genome } from '../genetics';
 import { Faction, FactionManager } from '../faction';
 
-const VERSION = '4.1.0';
+const VERSION = '4.1.1';
 
 // Inlined TUNE constants
 const FARM_MAX_SPAWNS = 12;

--- a/src/domains/simulation/agent-updater.ts
+++ b/src/domains/simulation/agent-updater.ts
@@ -869,12 +869,6 @@ export class AgentUpdater {
       }
     }
 
-    // ── Age-based death ──
-    if (agent.ageTicks >= agent.maxAgeTicks) {
-      agent.health = 0;
-      log(world, 'death', `${agent.name} died of old age`, agent.id, {});
-    }
-
     agent.clampStats();
 
     // ── Disease effects ──
@@ -898,6 +892,12 @@ export class AgentUpdater {
     }
     if (agent.fullness > FULLNESS_REGEN_THRESHOLD) {
       agent.healBy((REGEN_HP_PER_SEC * TICK_MS) / 1000);
+    }
+
+    // ── Age-based death (must be last — regen must not resurrect) ──
+    if (agent.ageTicks >= agent.maxAgeTicks) {
+      agent.health = 0;
+      log(world, 'death', `${agent.name} died of old age`, agent.id, {});
     }
   }
 

--- a/src/domains/simulation/agent-updater.ts
+++ b/src/domains/simulation/agent-updater.ts
@@ -196,6 +196,22 @@ function scanVision(world: World, agent: Agent): void {
       }
     }
   }
+
+  // Forget stale memories — if a remembered resource is within vision but gone, drop it
+  const memTypes: ResourceMemoryType[] = ['food', 'water', 'wood'];
+  for (const mt of memTypes) {
+    const entries = agent.resourceMemory.get(mt)!;
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const e = entries[i];
+      if (manhattan(agent.cellX, agent.cellY, e.x, e.y) > range) continue;
+      const k = key(e.x, e.y);
+      const exists = mt === 'food'
+        ? (world.foodBlocks.has(k) || world.seedlings.has(k))
+        : mt === 'water' ? world.waterBlocks.has(k)
+        : world.treeBlocks.has(k);
+      if (!exists) entries.splice(i, 1);
+    }
+  }
 }
 
 // ── Seek from memory ──

--- a/src/domains/simulation/agent-updater.ts
+++ b/src/domains/simulation/agent-updater.ts
@@ -722,7 +722,8 @@ export class AgentUpdater {
                 tryStartAction(agent,candidate.actionType, { targetPos: candidate.targetPos });
               }
             } else {
-              tryStartAction(agent,candidate.actionType);
+              const payload = candidate.resourceType ? { resourceType: candidate.resourceType } : undefined;
+              tryStartAction(agent,candidate.actionType, payload);
             }
           }
 

--- a/src/domains/ui/input-handler.ts
+++ b/src/domains/ui/input-handler.ts
@@ -34,6 +34,13 @@ export class InputHandler {
     let painting = false;
     let lastPaintKey: string | null = null;
 
+    // Touch-specific state for single-finger pan
+    let activeTouchCount = 0;
+    let isTouchDrag = false;
+    let touchStartX = 0;
+    let touchStartY = 0;
+    const TOUCH_DRAG_THRESHOLD = 8;
+
     function paintAtEvent(e: PointerEvent | MouseEvent) {
       const rect = canvas.getBoundingClientRect();
       const sx = (e.clientX - rect.left) * (canvas.width / rect.width);
@@ -92,6 +99,21 @@ export class InputHandler {
 
     canvas.addEventListener('pointerdown', (e) => {
       canvas.setPointerCapture(e.pointerId);
+
+      if (e.pointerType === 'touch') {
+        activeTouchCount++;
+        // Single-finger touch: prepare for pan (with drag threshold for tap detection)
+        if (activeTouchCount === 1 && world.paintMode === 'none') {
+          dragging = true;
+          isTouchDrag = false;
+          touchStartX = e.clientX;
+          touchStartY = e.clientY;
+          lastX = e.clientX;
+          lastY = e.clientY;
+          return;
+        }
+      }
+
       setAllowDrag(e);
       if (allowDrag) {
         dragging = true;
@@ -105,6 +127,29 @@ export class InputHandler {
     });
     canvas.addEventListener('contextmenu', (e) => e.preventDefault());
     canvas.addEventListener('pointermove', (e) => {
+      // Multi-touch: let the touch events handle zoom+pan
+      if (e.pointerType === 'touch' && activeTouchCount >= 2) {
+        dragging = false;
+        return;
+      }
+
+      // Single-finger touch pan
+      if (e.pointerType === 'touch' && dragging && world.paintMode === 'none') {
+        if (!isTouchDrag) {
+          const totalDx = e.clientX - touchStartX;
+          const totalDy = e.clientY - touchStartY;
+          if (Math.hypot(totalDx, totalDy) > TOUCH_DRAG_THRESHOLD) {
+            isTouchDrag = true;
+          }
+        }
+        if (isTouchDrag) {
+          camera.panBy(-(e.clientX - lastX), -(e.clientY - lastY));
+        }
+        lastX = e.clientX;
+        lastY = e.clientY;
+        return;
+      }
+
       setAllowDrag(e);
       if (dragging && allowDrag) {
         const dx = e.clientX - lastX;
@@ -116,7 +161,10 @@ export class InputHandler {
         paintAtEvent(e);
       }
     });
-    canvas.addEventListener('pointerup', () => {
+    canvas.addEventListener('pointerup', (e) => {
+      if (e.pointerType === 'touch') {
+        activeTouchCount = Math.max(0, activeTouchCount - 1);
+      }
       dragging = false;
       painting = false;
       lastPaintKey = null;
@@ -192,6 +240,8 @@ export class InputHandler {
 
     // Agent selection & replenish tool
     canvas.addEventListener('click', (e) => {
+      // Suppress click after a touch drag (tap = select, drag = pan)
+      if (isTouchDrag) { isTouchDrag = false; return; }
       const rect = canvas.getBoundingClientRect();
       const scaleX = canvas.width / rect.width;
       const scaleY = canvas.height / rect.height;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { TICK_MS, CELL_PX } from './core/constants';
 
-const VERSION = '4.1.0';
+const VERSION = '4.1.1';
 import { World } from './domains/world';
 import { Camera } from './domains/rendering/camera';
 import { Renderer } from './domains/rendering/renderer';


### PR DESCRIPTION
## Summary

- **Fix: deposit/withdraw resourceType dropped by DecisionEngine**: `resolveTarget()` had no cases for `deposit`/`withdraw` — they fell through to `default: return {}`, so `resourceType` was never set. Effects defaulted to `'food'`, causing agents with only water/wood to loop deposit/withdraw forever with no transfer. Added explicit `deposit` (picks resource agent has most of) and `withdraw` (picks based on need) cases, and forward `candidate.resourceType` as payload in the agent-updater fallthrough path.
- **Fix: stale resource memories not cleaned up on arrival**: `scanVision` added memories for seen resources but never pruned entries for resources within vision range that no longer exist. Agents would travel to a remembered location, find nothing, and keep the stale memory. Now after the vision scan, any memory entry within range is checked and removed if the resource is gone.
- **Fix: agents surviving past max age**: the age death check set `health=0` but fullness regen ran after it, calling `healBy(0.125)` each tick — just enough to stay above the `<= 0` threshold in `_cleanDead` while the UI showed "0" (`0.125.toFixed(0)`). Moved age death check to the end of the update method so it's the final health modification.
- **Feat: single-finger panning on mobile**: uses `pointerType` to distinguish touch from mouse. Single finger pans with an 8px drag threshold (taps still select agents). Two-finger pinch zoom+pan unchanged. Desktop mouse behavior unchanged.
- **Version bump**: 4.1.0 → 4.1.1

## Test plan

- [ ] Watch faction members near flag — confirm deposit/withdraw transfers food, water, and wood correctly
- [ ] Agents don't loop deposit/withdraw with unchanged inventory
- [ ] Agent navigates to remembered food location consumed by another agent — memory entry is cleared on arrival
- [ ] Agents past max lifespan die immediately (no 0 HP immortals)
- [ ] Mobile: single finger pans, tap selects agent, two-finger pinch zooms
- [ ] Desktop: click selects, right-click/modifier pans, scroll zooms (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)