### PR TITLE
feat: pregnancy mechanics, speed trait, persistence fixes, UX polish

### DIFF
--- a/src/domains/action/effects/reproduce-effects.ts
+++ b/src/domains/action/effects/reproduce-effects.ts
@@ -65,7 +65,8 @@ export function onReproduceComplete(world: World, agent: Agent, target: Agent | 
   // Start pregnancy on the initiator
   const babyDuration = childGenome.traits.maturity.babyDurationMs;
   const pregnancyDuration = babyDuration * 0.5;
-  agent.pregnancy.start(childDna, pregnancyDuration, familyName, factionId, target.id);
+  const totalDonated = p1Donate + p2Donate;
+  agent.pregnancy.start(childDna, pregnancyDuration, familyName, factionId, target.id, totalDonated);
 
   world.events.emit('pregnancy:started', { agentId: agent.id, duration: pregnancyDuration });
   log(world, 'reproduce', `${agent.name} & ${target.name} are expecting`, agent.id, { targetId: target.id });
@@ -96,7 +97,7 @@ function reproduceAsexual(world: World, agent: Agent): void {
 
   const babyDuration = childGenome.traits.maturity.babyDurationMs;
   const pregnancyDuration = babyDuration * 0.5;
-  agent.pregnancy.start(childDna, pregnancyDuration, agent.familyName, agent.factionId);
+  agent.pregnancy.start(childDna, pregnancyDuration, agent.familyName, agent.factionId, null, p1Donate);
 
   world.events.emit('pregnancy:started', { agentId: agent.id, duration: pregnancyDuration });
   log(world, 'reproduce', `${agent.name} is expecting (asexual)`, agent.id, {});

--- a/src/domains/entity/agent-factory.ts
+++ b/src/domains/entity/agent-factory.ts
@@ -32,7 +32,8 @@ export class AgentFactory {
     childDna: string,
     familyName: string,
     factionId: string | null,
-    parentGeneration: number = 1
+    parentGeneration: number = 1,
+    donatedFullness: number = 0
   ): Agent {
     const genome = new Genome(childDna);
     const name = generatePronounceableString(6);
@@ -48,6 +49,7 @@ export class AgentFactory {
       entityClass: 'baby',
       babyMsRemaining: genome.traits.maturity.babyDurationMs,
       energy: 50,
+      fullness: Math.max(5, donatedFullness),
       health: genome.traits.resilience.baseMaxHp,
       generation: parentGeneration + 1,
     });

--- a/src/domains/entity/agent.ts
+++ b/src/domains/entity/agent.ts
@@ -57,6 +57,9 @@ export class Agent {
   // Navigation
   pathFailCount: number;
 
+  // Movement speed accumulator (ephemeral, not persisted)
+  moveCredit: number;
+
   // Legacy fields
   poopTimerMs: number;
   babyMsRemaining: number;
@@ -135,6 +138,7 @@ export class Agent {
 
     // Navigation
     this.pathFailCount = 0;
+    this.moveCredit = 0;
 
     // Legacy
     this.poopTimerMs = opts.poopTimerMs ?? 0;

--- a/src/domains/entity/components/pregnancy.ts
+++ b/src/domains/entity/components/pregnancy.ts
@@ -5,14 +5,16 @@ export class PregnancyState {
   childFamilyName: string | null = null;
   childFactionId: string | null = null;
   partnerId: string | null = null;
+  donatedFullness = 0;
 
-  start(dna: string, durationMs: number, familyName: string, factionId: string | null, partnerId?: string | null): void {
+  start(dna: string, durationMs: number, familyName: string, factionId: string | null, partnerId?: string | null, donatedFullness?: number): void {
     this.active = true;
     this.remainingMs = durationMs;
     this.childDna = dna;
     this.childFamilyName = familyName;
     this.childFactionId = factionId;
     this.partnerId = partnerId ?? null;
+    this.donatedFullness = donatedFullness ?? 0;
   }
 
   /** Tick the pregnancy timer. Returns true when birth occurs. */
@@ -32,5 +34,6 @@ export class PregnancyState {
     this.childFamilyName = null;
     this.childFactionId = null;
     this.partnerId = null;
+    this.donatedFullness = 0;
   }
 }

--- a/src/domains/entity/family-registry.ts
+++ b/src/domains/entity/family-registry.ts
@@ -9,6 +9,12 @@ export interface FamilyStats {
 
 export class FamilyRegistry {
   private readonly families = new Map<string, FamilyStats>();
+  private _version = 0;
+  private _cachedAlive: FamilyStats[] = [];
+  private _cachedAliveVersion = -1;
+
+  /** Monotonic version counter — increments on every mutation. */
+  get version(): number { return this._version; }
 
   registerBirth(familyName: string, generation: number = 1): void {
     const stats = this.getOrCreate(familyName);
@@ -17,6 +23,7 @@ export class FamilyRegistry {
     if (generation > stats.maxGeneration) {
       stats.maxGeneration = generation;
     }
+    this._version++;
   }
 
   registerDeath(familyName: string, ageMs: number): void {
@@ -25,16 +32,26 @@ export class FamilyRegistry {
     stats.currentlyAlive = Math.max(0, stats.currentlyAlive - 1);
     stats.totalAgeMs += ageMs;
     stats.deathCount++;
+    this._version++;
   }
 
   getStats(familyName: string): FamilyStats | undefined {
     return this.families.get(familyName);
   }
 
+  /** Returns families with living members (cached, rebuilds only on mutation). */
   getAllFamilies(): FamilyStats[] {
-    return Array.from(this.families.values())
+    if (this._cachedAliveVersion === this._version) return this._cachedAlive;
+    this._cachedAlive = Array.from(this.families.values())
       .filter(f => f.currentlyAlive > 0)
       .sort((a, b) => b.currentlyAlive - a.currentlyAlive);
+    this._cachedAliveVersion = this._version;
+    return this._cachedAlive;
+  }
+
+  /** Returns all families including those with no living members (for serialization). */
+  getAllFamiliesIncludingDead(): FamilyStats[] {
+    return Array.from(this.families.values());
   }
 
   averageLongevity(familyName: string): number {
@@ -59,7 +76,13 @@ export class FamilyRegistry {
     return stats;
   }
 
+  restoreFamily(stats: FamilyStats): void {
+    this.families.set(stats.familyName, { ...stats });
+    this._version++;
+  }
+
   clear(): void {
     this.families.clear();
+    this._version++;
   }
 }

--- a/src/domains/persistence/persistence-manager.ts
+++ b/src/domains/persistence/persistence-manager.ts
@@ -70,7 +70,14 @@ export class PersistenceManager {
       createdAtTick: f.createdAtTick,
     }));
     const flags = [...world.flags.values()];
-    const obstacles = [...world.obstacles.values()];
+    // Deduplicate 2x2 obstacles (same object at 4 keys)
+    const obstaclesSeen = new Set<string>();
+    const obstacles: unknown[] = [];
+    for (const o of world.obstacles.values()) {
+      if (obstaclesSeen.has(o.id)) continue;
+      obstaclesSeen.add(o.id);
+      obstacles.push(o);
+    }
     const farms = [...world.farms.values()];
     const foodBlocks = [...world.foodBlocks.values()];
     const agents = world.agents.map((a) => ({
@@ -126,6 +133,7 @@ export class PersistenceManager {
         childFamilyName: a.pregnancy.childFamilyName,
         childFactionId: a.pregnancy.childFactionId,
         partnerId: a.pregnancy.partnerId,
+        donatedFullness: a.pregnancy.donatedFullness,
       } : null,
     }));
     return {
@@ -140,6 +148,8 @@ export class PersistenceManager {
         totalBirths: world.totalBirths,
         totalDeaths: world.totalDeaths,
         factionSort: world.factionSort,
+        familySort: world.familySort,
+        starredStats: world.starredStats,
       },
       factions,
       flags,
@@ -154,6 +164,14 @@ export class PersistenceManager {
       saltWaterBlocks: [...world.saltWaterBlocks.values()],
       eggs: [...world.eggs.values()],
       agents,
+      familyRegistry: world.familyRegistry.getAllFamiliesIncludingDead().map(f => ({
+        familyName: f.familyName,
+        totalBorn: f.totalBorn,
+        currentlyAlive: f.currentlyAlive,
+        totalAgeMs: f.totalAgeMs,
+        deathCount: f.deathCount,
+        maxGeneration: f.maxGeneration,
+      })),
       log: { limit: world.log.limit, arr: world.log.arr },
       selectedId: world.selectedId,
       activeLogCats: [...world.activeLogCats],
@@ -214,6 +232,7 @@ export class PersistenceManager {
     world.agents.length = 0;
     world.agentsById.clear();
     world.factions.clear();
+    world.familyRegistry.clear();
     world.tick = d.state?.tick ?? 0;
     world.speedPct = d.state?.speedPct ?? world.speedPct;
     world.cloudSpawnRate = d.state?.cloudSpawnRate ?? world.cloudSpawnRate;
@@ -222,6 +241,10 @@ export class PersistenceManager {
     world.totalBirths = d.state?.totalBirths ?? 0;
     world.totalDeaths = d.state?.totalDeaths ?? 0;
     world.factionSort = d.state?.factionSort ?? 'members';
+    world.familySort = d.state?.familySort ?? 'alive';
+    if (Array.isArray(d.state?.starredStats)) {
+      world.starredStats = d.state.starredStats;
+    }
 
     for (const f of d.factions || []) {
       const faction = new Faction(f.id, f.color, new Set(f.members || []), f.createdAtTick ?? 0);
@@ -234,8 +257,15 @@ export class PersistenceManager {
       });
       world.flagCells.add(key(fl.x, fl.y));
     }
-    for (const o of d.obstacles || d.walls || [])
-      world.obstacles.set(key(o.x, o.y), { ...o, emoji: o.emoji || '🪨' });
+    for (const o of d.obstacles || d.walls || []) {
+      const obs = { ...o, emoji: o.emoji || '🪨' };
+      world.obstacles.set(key(o.x, o.y), obs);
+      if (o.size === '2x2') {
+        world.obstacles.set(key(o.x + 1, o.y), obs);
+        world.obstacles.set(key(o.x, o.y + 1), obs);
+        world.obstacles.set(key(o.x + 1, o.y + 1), obs);
+      }
+    }
     for (const fm of d.farms || []) {
       world.farms.set(key(fm.x, fm.y), {
         ...fm,
@@ -329,6 +359,20 @@ export class PersistenceManager {
     world.clouds = [];
     world._nextCloudSpawnMs = 0;
 
+    // Restore family registry (before agents, so we don't double-count)
+    if (Array.isArray(d.familyRegistry)) {
+      for (const f of d.familyRegistry) {
+        world.familyRegistry.restoreFamily({
+          familyName: f.familyName,
+          totalBorn: f.totalBorn ?? 0,
+          currentlyAlive: f.currentlyAlive ?? 0,
+          totalAgeMs: f.totalAgeMs ?? 0,
+          deathCount: f.deathCount ?? 0,
+          maxGeneration: f.maxGeneration ?? 1,
+        });
+      }
+    }
+
     for (const a of d.agents || []) {
       let action = a.action ? { ...a.action } : null;
       // Backward compat: rename 'help' → 'share'
@@ -387,7 +431,8 @@ export class PersistenceManager {
           a.pregnancy.remainingMs ?? 0,
           a.pregnancy.childFamilyName ?? agent.familyName,
           a.pregnancy.childFactionId ?? null,
-          a.pregnancy.partnerId ?? null
+          a.pregnancy.partnerId ?? null,
+          a.pregnancy.donatedFullness ?? 0
         );
       }
 
@@ -395,8 +440,10 @@ export class PersistenceManager {
       world.agentsById.set(agent.id, agent);
       world.agentsByCell.set(key(agent.cellX, agent.cellY), agent.id);
 
-      // Register in family registry
-      world.familyRegistry.registerBirth(agent.familyName);
+      // Only register births if no saved family registry (backward compat)
+      if (!Array.isArray(d.familyRegistry)) {
+        world.familyRegistry.registerBirth(agent.familyName, agent.generation);
+      }
     }
 
     FactionManager.reconcile(world);
@@ -427,11 +474,21 @@ export class PersistenceManager {
     if (dom.gridChk) dom.gridChk.checked = world.drawGrid;
     if (dom.pauseChk) dom.pauseChk.checked = world.pauseOnBlur;
     if (dom.factionSortEl) dom.factionSortEl.value = world.factionSort;
+    if (dom.familySortEl) dom.familySortEl.value = world.familySort;
     if (dom.ranges.rngSpeed) dom.ranges.rngSpeed.value = String(world.speedPct);
     if (dom.nums.numSpeed) dom.nums.numSpeed.value = String(world.speedPct);
     if (dom.labels.lblSpeed) dom.labels.lblSpeed.textContent = `${world.speedPct}%`;
     if (dom.ranges.rngCloudRate) dom.ranges.rngCloudRate.value = String(world.cloudSpawnRate);
     if (dom.nums.numCloudRate) dom.nums.numCloudRate.value = String(world.cloudSpawnRate);
     if (dom.labels.lblCloudRate) dom.labels.lblCloudRate.textContent = world.cloudSpawnRate.toFixed(1) + '\u00d7';
+    // Sync starred stat buttons
+    document.querySelectorAll('.telemetry-star').forEach((btn) => {
+      const stat = (btn as HTMLElement).dataset['stat'];
+      if (stat && world.starredStats.includes(stat)) {
+        btn.classList.add('starred');
+      } else {
+        btn.classList.remove('starred');
+      }
+    });
   }
 }

--- a/src/domains/simulation/agent-updater.ts
+++ b/src/domains/simulation/agent-updater.ts
@@ -601,9 +601,27 @@ export class AgentUpdater {
 
     // Pregnancy timer
     if (agent.pregnancy.active) {
-      const birth = agent.pregnancy.tick(TICK_MS);
-      if (birth) {
-        AgentUpdater._handleBirth(world, agent);
+      // Miscarriage: starvation ends pregnancy immediately
+      if (agent.fullness <= 0) {
+        agent.pregnancy.clear();
+        log(world, 'reproduce', `${agent.name} lost the pregnancy (starvation)`, agent.id, {});
+        world.events.emit('pregnancy:miscarriage', { agentId: agent.id, cause: 'starvation' });
+      }
+      // Miscarriage: sickness has a per-tick chance scaled by fertility
+      // Lower energyThreshold = more fertile = more resistant (range 50-130)
+      else if (agent.diseased) {
+        const threshold = agent.traits.fertility.energyThreshold;
+        const miscarriageChance = ((threshold - 50) / 80) * 0.008;
+        if (Math.random() < miscarriageChance) {
+          agent.pregnancy.clear();
+          log(world, 'reproduce', `${agent.name} lost the pregnancy (illness)`, agent.id, {});
+          world.events.emit('pregnancy:miscarriage', { agentId: agent.id, cause: 'disease' });
+        }
+      } else {
+        const birth = agent.pregnancy.tick(TICK_MS);
+        if (birth) {
+          AgentUpdater._handleBirth(world, agent);
+        }
       }
     }
 
@@ -643,59 +661,66 @@ export class AgentUpdater {
     } else {
       const locked = agent.lockMsRemaining > 0 && !agent._underAttack;
       if (!locked) {
-        // ── Path following ──
+        // ── Path following (speed-based: slow agents skip ticks, fast agents always move) ──
         if (agent.path && agent.pathIdx < agent.path.length) {
-          const step = agent.path[agent.pathIdx];
-          if (world.grid.isBlockedTerrain(step.x, step.y)) {
-            agent.path = null;
-          } else {
-            const cellKey = key(step.x, step.y);
-            const occupant = world.grid.agentsByCell.get(cellKey);
-            const hasOtherAgent = occupant != null && occupant !== agent.id;
-            const isLastStep = agent.pathIdx === agent.path.length - 1;
+          const effectiveSpeed = agent.traits.agility.speedMult * agent.speedMult;
+          agent.moveCredit = Math.min(agent.moveCredit + effectiveSpeed, 2);
 
-            let targetX = step.x;
-            let targetY = step.y;
-            let canMove = true;
-
-            if (hasOtherAgent && isLastStep) {
-              const fallback = findAdjacentOpen(world, step.x, step.y, agent.id);
-              if (fallback) {
-                targetX = fallback.x;
-                targetY = fallback.y;
-              } else {
-                canMove = false;
-              }
-            }
-
-            if (canMove) {
-              agent.prevCellX = agent.cellX;
-              agent.prevCellY = agent.cellY;
-              agent.lerpT = 0;
-              const oldKey = key(agent.cellX, agent.cellY);
-              if (world.agentsByCell.get(oldKey) === agent.id) {
-                world.agentsByCell.delete(oldKey);
-              }
-              agent.cellX = targetX;
-              agent.cellY = targetY;
-              const newKey = key(agent.cellX, agent.cellY);
-              const newOccupant = world.agentsByCell.get(newKey);
-              if (!newOccupant || newOccupant === agent.id) {
-                world.agentsByCell.set(newKey, agent.id);
-              }
-              agent.pathIdx++;
-              agent.energy -= MOVE_ENERGY;
-              agent.drainFullness(FULLNESS_MOVE_DECAY);
-              agent.hygiene = Math.max(0, agent.hygiene - HYGIENE_MOVE_DECAY);
-              if (world.poopBlocks.has(key(agent.cellX, agent.cellY))) {
-                agent.hygiene = Math.max(0, agent.hygiene - HYGIENE_STEP_ON_POOP_DECAY);
-              }
-            } else {
+          if (agent.moveCredit >= 1) {
+            const step = agent.path[agent.pathIdx];
+            if (world.grid.isBlockedTerrain(step.x, step.y)) {
               agent.path = null;
+            } else {
+              const cellKey = key(step.x, step.y);
+              const occupant = world.grid.agentsByCell.get(cellKey);
+              const hasOtherAgent = occupant != null && occupant !== agent.id;
+              const isLastStep = agent.pathIdx === agent.path.length - 1;
+
+              let targetX = step.x;
+              let targetY = step.y;
+              let canMove = true;
+
+              if (hasOtherAgent && isLastStep) {
+                const fallback = findAdjacentOpen(world, step.x, step.y, agent.id);
+                if (fallback) {
+                  targetX = fallback.x;
+                  targetY = fallback.y;
+                } else {
+                  canMove = false;
+                }
+              }
+
+              if (canMove) {
+                agent.prevCellX = agent.cellX;
+                agent.prevCellY = agent.cellY;
+                agent.lerpT = 0;
+                const oldKey = key(agent.cellX, agent.cellY);
+                if (world.agentsByCell.get(oldKey) === agent.id) {
+                  world.agentsByCell.delete(oldKey);
+                }
+                agent.cellX = targetX;
+                agent.cellY = targetY;
+                const newKey = key(agent.cellX, agent.cellY);
+                const newOccupant = world.agentsByCell.get(newKey);
+                if (!newOccupant || newOccupant === agent.id) {
+                  world.agentsByCell.set(newKey, agent.id);
+                }
+                agent.pathIdx++;
+                agent.moveCredit -= 1;
+                agent.energy -= MOVE_ENERGY;
+                agent.drainFullness(FULLNESS_MOVE_DECAY);
+                agent.hygiene = Math.max(0, agent.hygiene - HYGIENE_MOVE_DECAY);
+                if (world.poopBlocks.has(key(agent.cellX, agent.cellY))) {
+                  agent.hygiene = Math.max(0, agent.hygiene - HYGIENE_STEP_ON_POOP_DECAY);
+                }
+              } else {
+                agent.path = null;
+              }
             }
           }
         } else {
           agent.path = null;
+          agent.moveCredit = 0;
         }
 
         // Ensure stationary agents on unique cell
@@ -929,7 +954,8 @@ export class AgentUpdater {
       preg.childDna,
       preg.childFamilyName ?? agent.familyName,
       preg.childFactionId,
-      agent.generation
+      agent.generation,
+      preg.donatedFullness
     );
 
     world.agents.push(child);

--- a/src/domains/simulation/spawner.ts
+++ b/src/domains/simulation/spawner.ts
@@ -330,15 +330,23 @@ export class Spawner {
     for (const tree of world.treeBlocks.values()) {
       if (tree.units <= 0) continue;
       const nearPoop = Spawner.hasPoopNearby(world, tree.x, tree.y, TREE_POOP_BOOST_SEEDLING_RADIUS);
-      const seedlingChance = nearPoop
-        ? TREE_SEEDLING_PASSIVE_CHANCE * 2
-        : TREE_SEEDLING_PASSIVE_CHANCE;
+      const hydrated = Spawner.hasWaterNearby(world, tree.x, tree.y, TREE_WATER_REQUIRED_FOR_SEEDLING);
+      let seedlingChance = TREE_SEEDLING_PASSIVE_CHANCE;
+      if (hydrated) seedlingChance *= 3;
+      if (nearPoop) seedlingChance *= 2;
       if (Math.random() < seedlingChance) {
         Spawner.trySpawnSeedling(world, tree.x, tree.y);
       } else if (nearPoop && Math.random() < TREE_FOOD_PASSIVE_CHANCE) {
         Spawner.trySpawnFoodNearTree(world, tree.x, tree.y);
       }
     }
+  }
+
+  static hasWaterNearby(world: World, x: number, y: number, radius: number): boolean {
+    for (const wb of world.waterBlocks.values()) {
+      if (manhattan(x, y, wb.x, wb.y) <= radius) return true;
+    }
+    return false;
   }
 
   // ── Saltwater spawning ──

--- a/src/domains/ui/controls.ts
+++ b/src/domains/ui/controls.ts
@@ -207,6 +207,12 @@ export class Controls {
       PersistenceManager.saveToLocalStorage(world);
       world.log.push({ t: performance.now(), cat: 'info', msg: 'State saved', actorId: null, extra: {} });
       doRenderLog();
+      // Flash button to confirm save
+      const btn = buttons.btnQuickSave!;
+      const orig = btn.textContent;
+      btn.textContent = 'Saved!';
+      btn.disabled = true;
+      setTimeout(() => { btn.textContent = orig; btn.disabled = false; }, 1200);
     });
     buttons.btnExport?.addEventListener('click', () => PersistenceManager.export(world, doRenderLog));
     buttons.btnImport?.addEventListener('click', () => dom.fileLoad?.click());

--- a/src/domains/ui/ui-manager.ts
+++ b/src/domains/ui/ui-manager.ts
@@ -7,6 +7,17 @@ import { GENE_REGISTRY } from '../genetics/gene-registry';
 
 const PAGE_LOAD_TIME = Date.now() - performance.now();
 
+/** Format large numbers compactly: 1000→1k, 1500→1.5k, 1000000→1m */
+function compactNum(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) {
+    const k = n / 1000;
+    return (k % 1 === 0 ? k.toFixed(0) : k.toFixed(1)) + 'k';
+  }
+  const m = n / 1_000_000;
+  return (m % 1 === 0 ? m.toFixed(0) : m.toFixed(1)) + 'm';
+}
+
 /**
  * Color-code a trait value based on where it falls in the [min, max] range.
  * Red = 2+ SD below midpoint, Yellow = 1 SD below, normal = within 1 SD,
@@ -350,22 +361,22 @@ export class UIManager {
     const rMax = (stats.renderMax as number) || 0;
 
     const s = stats as Record<string, HTMLElement | null>;
-    if (s.stAgents) s.stAgents.textContent = String(world.agents.length);
-    if (s.stFactions) s.stFactions.textContent = String(world.factions.size);
-    if (s.stCrops) s.stCrops.textContent = String(world.foodBlocks.size);
-    if (s.stFarms) s.stFarms.textContent = String(world.farms.size);
-    if (s.stObstacles) s.stObstacles.textContent = String(world.obstacles.size);
-    if (s.stFlags) s.stFlags.textContent = String(world.flags.size);
+    if (s.stAgents) s.stAgents.textContent = compactNum(world.agents.length);
+    if (s.stFactions) s.stFactions.textContent = compactNum(world.factions.size);
+    if (s.stCrops) s.stCrops.textContent = compactNum(world.foodBlocks.size);
+    if (s.stFarms) s.stFarms.textContent = compactNum(world.farms.size);
+    if (s.stObstacles) s.stObstacles.textContent = compactNum(world.obstacles.size);
+    if (s.stFlags) s.stFlags.textContent = compactNum(world.flags.size);
 
     const birthsPerMin = UIManager._ratePerMinute(world.birthTimestamps);
     const deathsPerMin = UIManager._ratePerMinute(world.deathTimestamps);
-    if (s.stBirths) s.stBirths.textContent = `${world.totalBirths} (${birthsPerMin}/m)`;
-    if (s.stDeaths) s.stDeaths.textContent = `${world.totalDeaths} (${deathsPerMin}/m)`;
+    if (s.stBirths) s.stBirths.textContent = `${compactNum(world.totalBirths)} (${compactNum(birthsPerMin)}/m)`;
+    if (s.stDeaths) s.stDeaths.textContent = `${compactNum(world.totalDeaths)} (${compactNum(deathsPerMin)}/m)`;
     // Count unique water blocks (large blocks share references across cells)
     const seenWater = new Set<string>();
     for (const wb of world.waterBlocks.values()) seenWater.add(wb.id);
-    if (s.stWater) s.stWater.textContent = String(seenWater.size);
-    if (s.stTrees) s.stTrees.textContent = String(world.treeBlocks.size);
+    if (s.stWater) s.stWater.textContent = compactNum(seenWater.size);
+    if (s.stTrees) s.stTrees.textContent = compactNum(world.treeBlocks.size);
     if (s.stTick) s.stTick.textContent = UIManager.formatTickCount(world.tick);
     if (s.stFps) s.stFps.textContent = fps.toFixed(0);
     if (s.stTickAvg) s.stTickAvg.textContent = tAvg.toFixed(1);


### PR DESCRIPTION
## Summary

- **Pregnancy miscarriage**: ends immediately on starvation; disease causes a per-tick chance scaled by the fertility gene (more fertile = more resistant)
- **Baby fullness transfer**: babies now receive parents' donated fullness at birth instead of a free 50
- **Speed trait**: agility `speedMult` applied via move-credit accumulator — slow agents skip movement ticks, fast agents always move; interpolation stays smooth (max 1 step per tick)
- **Persistence fixes**: 2x2 obstacles were lost on save/restore (now properly deduplicated on serialize, all 4 cells restored); family registry stats (totalBorn, deaths, generations), `starredStats`, `familySort`, and pregnancy `donatedFullness` all persisted; star button state synced on restore
- **Family registry cache**: `getAllFamilies()` now uses a version-gated cache to avoid redundant array creation each render cycle
- **Hydrated tree seedlings**: trees near water get 3× seedling spawn rate (stacks with poop 2× boost)
- **Save button feedback**: shows "Saved!" and disables for 1.2s after click
- **Compact number formatting**: HUD stats display `1k`/`1m` etc. to prevent overflow

## Test plan

- [ ] Pregnant agent starves to 0 fullness → pregnancy clears, log shows miscarriage
- [ ] Sick pregnant agent → occasional miscarriage log entries over time; healthy/high-fertility agents miscarry less
- [ ] Newborn baby fullness reflects parents' donation (~30–50 range), not always 50
- [ ] Low-agility agents visibly move slower than high-agility agents
- [ ] Save → reload: 2x2 rock obstacles fully block all 4 cells
- [ ] Save → reload: starred stats, family sort, faction sort, family registry totals all restored correctly
- [ ] Trees adjacent to water spawn seedlings noticeably faster than dry trees
- [ ] Clicking Save shows "Saved!" then reverts
- [ ] Stats with large numbers (1000+) display as 1k, 1.5k, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)