### PR TITLE
feat: mood system, mate seeking, and maternity gene

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -61,16 +61,19 @@ export const AGENT_EMOJIS: Record<string, string> = {
   clean: '\u{1F637}',
   play: '\u{1F92A}',
   build_farm: '\u{1F920}',
+  seek_mate: '\u{1F495}',
+  await_mate: '\u{1F497}',
 };
 
 export const IDLE_EMOJIS = {
   baby: '\u{1F476}',
   babyEating: '\u{1F47C}',
-  lowEnergy: '\u{1F924}',
-  lowHealth: '\u{1F915}',
-  lowFullness: '\u{1F629}',
   diseased: '\u{1F922}',
-  highEnergy: '\u{1F600}',
+  // Mood-based idle emojis
+  happy: '\u{1F600}',       // 😀
+  content: '\u{1F642}',     // 🙂
+  unhappy: '\u{1F629}',     // 😩
+  frustrated: '\u{1F621}',  // 😡
   default: '\u{1F642}',
 };
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -63,18 +63,12 @@ export class RingLog {
 }
 
 export const getIdleEmoji = (a: {
-  energy: number;
-  health: number;
-  fullness: number;
   diseased?: boolean;
   babyMsRemaining?: number;
-}): string => {
+}, mood?: string): string => {
   if (a.babyMsRemaining && a.babyMsRemaining > 0) return IDLE_EMOJIS.baby;
   if (a.diseased) return IDLE_EMOJIS.diseased;
-  if (a.fullness <= 20) return IDLE_EMOJIS.lowFullness;
-  if (a.energy <= 20) return IDLE_EMOJIS.lowEnergy;
-  if (a.health <= 30) return IDLE_EMOJIS.lowHealth;
-  if (a.energy >= 80) return IDLE_EMOJIS.highEnergy;
+  if (mood && mood in IDLE_EMOJIS) return IDLE_EMOJIS[mood as keyof typeof IDLE_EMOJIS];
   return IDLE_EMOJIS.default;
 };
 

--- a/src/domains/action/action-processor.ts
+++ b/src/domains/action/action-processor.ts
@@ -18,7 +18,7 @@ const FULLNESS_ACTION_DECAY_PER_SEC = 0.02;
 const LOW_ENERGY_EXEMPT = new Set([
   'attack', 'sleep', 'harvest', 'eat', 'wash',
   'deposit', 'withdraw', 'pickup', 'poop', 'clean',
-  'play', 'build_farm',
+  'play', 'build_farm', 'await_mate',
 ]);
 
 export class ActionProcessor {
@@ -26,8 +26,14 @@ export class ActionProcessor {
     if (!agent.action) return;
     const act = agent.action;
 
-    // Sleep is interruptible by attack
-    if (act.type === 'sleep' && agent._underAttack) {
+    // Sleep and await_mate are interruptible by attack
+    if ((act.type === 'sleep' || act.type === 'await_mate') && agent._underAttack) {
+      agent.action = null;
+      return;
+    }
+
+    // Cancel reproduce on critical hunger
+    if (act.type === 'reproduce' && agent.fullness <= 20) {
       agent.action = null;
       return;
     }

--- a/src/domains/action/action-registry.ts
+++ b/src/domains/action/action-registry.ts
@@ -159,4 +159,22 @@ export const ACTION_REGISTRY: ReadonlyMap<ActionType, ActionDef> = new Map<Actio
     targetRange: 0,
     interruptible: false,
   }],
+  ['seek_mate', {
+    type: 'seek_mate',
+    tags: new Set([ActionTag.SOCIAL]),
+    energyCost: 0,
+    durationRange: [0, 0],
+    requiresTarget: true,
+    targetRange: 10,
+    interruptible: true,
+  }],
+  ['await_mate', {
+    type: 'await_mate',
+    tags: new Set([ActionTag.SOCIAL]),
+    energyCost: 0.1,
+    durationRange: [15000, 20000],
+    requiresTarget: false,
+    targetRange: 0,
+    interruptible: true,
+  }],
 ]);

--- a/src/domains/action/types.ts
+++ b/src/domains/action/types.ts
@@ -15,7 +15,9 @@ export type ActionType =
   | 'poop'
   | 'clean'
   | 'play'
-  | 'build_farm';
+  | 'build_farm'
+  | 'seek_mate'
+  | 'await_mate';
 
 export enum ActionTag {
   COMBAT = 'combat',

--- a/src/domains/decision/action-scorer.ts
+++ b/src/domains/decision/action-scorer.ts
@@ -1,6 +1,6 @@
 import { clamp } from '../../core/utils';
 import type { Agent } from '../entity/agent';
-import { NeedBand } from '../entity/types';
+import { NeedBand, Mood } from '../entity/types';
 import { ActionTag } from '../action/types';
 import type { ActionDef } from '../action/types';
 import type { DecisionContext } from './types';
@@ -35,10 +35,13 @@ export function scoreAction(
   // 3. Genetic modifier
   score += geneticScore(action, agent);
 
-  // 4. Situational modifier
+  // 4. Mood modifier
+  score += moodScore(action, agent, context);
+
+  // 5. Situational modifier
   score += situationalScore(action, agent, context);
 
-  // 5. Random noise (±5% of score magnitude)
+  // 6. Random noise (±5% of score magnitude)
   const noise = (Math.random() - 0.5) * 0.1;
   score *= 1 + noise;
 
@@ -58,6 +61,16 @@ function hardOverride(action: ActionDef, agent: Agent, context: DecisionContext)
 
   // Elders can't reproduce
   if (action.type === 'reproduce' && agent.entityClass === 'elder') {
+    return -Infinity;
+  }
+
+  // Unhappy/frustrated agents won't initiate reproduction
+  if (action.type === 'reproduce' && (context.mood === Mood.UNHAPPY || context.mood === Mood.FRUSTRATED)) {
+    return -Infinity;
+  }
+
+  // Block seek_mate when unhappy or frustrated
+  if (action.type === 'seek_mate' && (context.mood === Mood.UNHAPPY || context.mood === Mood.FRUSTRATED)) {
     return -Infinity;
   }
 
@@ -122,8 +135,8 @@ function geneticScore(action: ActionDef, agent: Agent): number {
     score += (1 - agent.traits.fidelity.leaveProbability) * 30;
   }
 
-  // Fertility boosts reproduction
-  if (action.type === 'reproduce') {
+  // Fertility boosts reproduction and mate seeking
+  if (action.type === 'reproduce' || action.type === 'seek_mate') {
     // Higher fertility (lower energyThreshold) means more eagerness
     const fertilityScore = (130 - agent.traits.fertility.energyThreshold) / 80;
     score += fertilityScore * 60;
@@ -132,6 +145,38 @@ function geneticScore(action: ActionDef, agent: Agent): number {
     const ageRatio = agent.maxAgeTicks > 0 ? agent.ageTicks / agent.maxAgeTicks : 0;
     if (ageRatio > agent.traits.fertility.urgencyAge) {
       score += 300;
+    }
+  }
+
+  return score;
+}
+
+function moodScore(action: ActionDef, agent: Agent, context: DecisionContext): number {
+  let score = 0;
+  const mood = context.mood;
+
+  // Happy: boost reproduction, mate seeking, and building
+  if (mood === Mood.HAPPY) {
+    if (action.type === 'reproduce' || action.type === 'seek_mate') {
+      const fertilityBonus = (130 - agent.traits.fertility.energyThreshold) / 80;
+      score += 150 + fertilityBonus * 50;
+    }
+    if (action.type === 'build_farm') {
+      score += 80;
+    }
+  }
+
+  // Content: boost positive social interactions
+  if (mood === Mood.CONTENT) {
+    if (action.type === 'talk' || action.type === 'share' || action.type === 'heal') {
+      score += 60;
+    }
+  }
+
+  // Frustrated: boost aggressive actions
+  if (mood === Mood.FRUSTRATED) {
+    if (action.tags.has(ActionTag.COMBAT)) {
+      score += 80;
     }
   }
 
@@ -169,15 +214,20 @@ function situationalScore(action: ActionDef, agent: Agent, context: DecisionCont
     score += 100;
   }
 
+  // Eligible partners for mate seeking
+  if (action.type === 'seek_mate') {
+    const seekPartners = context.nearbyAgents.filter(
+      n => n.dist > 1 && n.relationship >= 0.4 && !n.agent.diseased
+    );
+    if (seekPartners.length > 0) score += 150;
+  }
+
   // Adjacent partner for reproduction
   if (action.type === 'reproduce') {
     const adjPartners = context.nearbyAgents.filter(
-      n => n.dist === 1 && n.relationship >= 0.4 &&
-        n.agent.energy >= agent.traits.fertility.energyThreshold &&
-        !n.agent.diseased
+      n => n.dist === 1 && n.relationship >= 0.4 && !n.agent.diseased
     );
     if (adjPartners.length > 0) score += 200;
-    else score -= 500; // No valid partner = don't bother
   }
 
   // Loot nearby boosts pickup

--- a/src/domains/decision/context-builder.ts
+++ b/src/domains/decision/context-builder.ts
@@ -1,8 +1,8 @@
 import { key, manhattan } from '../../core/utils';
 import type { Agent } from '../entity/agent';
 import type { World } from '../world/world';
-import { NeedBand } from '../entity/types';
 import { evaluateNeeds } from './need-evaluator';
+import { computeMood } from './mood-evaluator';
 import type { DecisionContext, NearbyAgent, NearbyResource, NearbyBlock } from './types';
 
 const DEFAULT_VISION_RANGE = 10;
@@ -79,16 +79,19 @@ export class ContextBuilder {
       }
     }
 
+    const needBands = evaluateNeeds(agent);
+
     return {
       agent,
       nearbyAgents,
       nearbyResources,
       nearbyBlocks,
-      needBands: evaluateNeeds(agent),
+      needBands,
       underAttack: agent._underAttack,
       pregnant: agent.pregnancy.active,
       nearOwnFlag,
       ownFlagPos,
+      mood: computeMood(needBands),
     };
   }
 }

--- a/src/domains/decision/decision-engine.ts
+++ b/src/domains/decision/decision-engine.ts
@@ -4,6 +4,7 @@ import type { Agent } from '../entity/agent';
 import { ENTITY_CLASSES } from '../entity/entity-class';
 import { ACTION_REGISTRY } from '../action/action-registry';
 import type { ActionType } from '../action/types';
+import { Mood } from '../entity/types';
 import { shouldFlee } from './flee-evaluator';
 import { scoreAction } from './action-scorer';
 import type { DecisionContext, ActionCandidate } from './types';
@@ -93,17 +94,31 @@ function passesRequirements(type: ActionType, agent: Agent, ctx: DecisionContext
     case 'reproduce': {
       if (agent.pregnancy.active) return false;
       if (agent.entityClass === 'elder') return false;
-      if (agent.energy < agent.traits.fertility.energyThreshold) return false;
       // Parthenogenesis: no partner needed
       if (agent.traits.parthenogenesis.canSelfReproduce) return true;
-      // Need adjacent partner with sufficient relationship and energy
+      // Need adjacent partner with sufficient relationship, not diseased
       const partners = ctx.nearbyAgents.filter(
         n => n.dist === 1 &&
           n.relationship >= 0.4 &&
-          n.agent.energy >= agent.traits.fertility.energyThreshold &&
           !n.agent.diseased && !agent.diseased
       );
       return partners.length > 0;
+    }
+    case 'seek_mate': {
+      if (agent.traits.parthenogenesis.canSelfReproduce) return false;
+      if (agent.pregnancy.active) return false;
+      if (agent.entityClass === 'elder') return false;
+      if (agent.matingTargetId) return false;
+      if (ctx.mood !== Mood.HAPPY) return false;
+      const seekPartners = ctx.nearbyAgents.filter(
+        n => n.dist > 1 &&
+          n.relationship >= 0.4 &&
+          !n.agent.diseased && !agent.diseased &&
+          !n.agent.pregnancy.active &&
+          n.agent.entityClass !== 'elder' &&
+          n.agent.entityClass !== 'baby'
+      );
+      return seekPartners.length > 0;
     }
     case 'harvest': {
       if (agent.inventoryFull()) return false;
@@ -176,11 +191,23 @@ function resolveTarget(
     case 'reproduce': {
       if (agent.traits.parthenogenesis.canSelfReproduce) return {};
       const partners = ctx.nearbyAgents.filter(
-        n => n.dist === 1 && n.relationship >= 0.4 &&
-          n.agent.energy >= agent.traits.fertility.energyThreshold
+        n => n.dist === 1 && n.relationship >= 0.4 && !n.agent.diseased
       );
       if (!partners.length) return null;
       return { targetId: partners[0].agent.id };
+    }
+    case 'seek_mate': {
+      const seekPartners = ctx.nearbyAgents.filter(
+        n => n.dist > 1 &&
+          n.relationship >= 0.4 &&
+          !n.agent.diseased &&
+          !n.agent.pregnancy.active &&
+          n.agent.entityClass !== 'elder' &&
+          n.agent.entityClass !== 'baby'
+      );
+      if (!seekPartners.length) return null;
+      seekPartners.sort((a, b) => b.relationship - a.relationship);
+      return { targetId: seekPartners[0].agent.id };
     }
     case 'harvest': {
       const adjRes = ctx.nearbyResources.filter(r => r.dist <= 1);

--- a/src/domains/decision/index.ts
+++ b/src/domains/decision/index.ts
@@ -4,3 +4,4 @@ export { ContextBuilder } from './context-builder';
 export { scoreAction } from './action-scorer';
 export { evaluateNeeds } from './need-evaluator';
 export { shouldFlee } from './flee-evaluator';
+export { computeMood } from './mood-evaluator';

--- a/src/domains/decision/mood-evaluator.ts
+++ b/src/domains/decision/mood-evaluator.ts
@@ -1,0 +1,19 @@
+import { NeedBand, Mood } from '../entity/types';
+
+/**
+ * Compute an agent's mood from their current need bands.
+ *
+ * Priority (highest first):
+ *   1. Any need CRITICAL → Frustrated
+ *   2. Any need LOW      → Unhappy
+ *   3. All needs HIGH/FULL → Happy
+ *   4. Otherwise          → Content
+ */
+export function computeMood(needBands: Record<string, NeedBand>): Mood {
+  const bands = Object.values(needBands);
+
+  if (bands.some(b => b === NeedBand.CRITICAL)) return Mood.FRUSTRATED;
+  if (bands.some(b => b === NeedBand.LOW)) return Mood.UNHAPPY;
+  if (bands.every(b => b === NeedBand.HIGH || b === NeedBand.FULL)) return Mood.HAPPY;
+  return Mood.CONTENT;
+}

--- a/src/domains/decision/types.ts
+++ b/src/domains/decision/types.ts
@@ -1,7 +1,7 @@
 import type { IPosition } from '../../core/types';
 import type { Agent } from '../entity/agent';
 import type { ActionType } from '../action/types';
-import type { NeedBand } from '../entity/types';
+import type { NeedBand, Mood } from '../entity/types';
 
 export interface NearbyAgent {
   readonly agent: Agent;
@@ -34,6 +34,7 @@ export interface DecisionContext {
   readonly pregnant: boolean;
   readonly nearOwnFlag: boolean;
   readonly ownFlagPos: IPosition | null;
+  readonly mood: Mood;
 }
 
 export interface ActionCandidate {

--- a/src/domains/entity/agent.ts
+++ b/src/domains/entity/agent.ts
@@ -50,9 +50,11 @@ export class Agent {
   action: IActionState | null;
   lockMsRemaining: number;
   _underAttack: boolean;
+  matingTargetId: string | null;
 
   // Lineage
   generation: number;
+  parentIds: string[];
 
   // Navigation
   pathFailCount: number;
@@ -132,9 +134,11 @@ export class Agent {
     this.action = opts.action ?? null;
     this.lockMsRemaining = opts.lockMsRemaining ?? 0;
     this._underAttack = false;
+    this.matingTargetId = opts.matingTargetId ?? null;
 
     // Lineage
     this.generation = opts.generation ?? 1;
+    this.parentIds = opts.parentIds ?? [];
 
     // Navigation
     this.pathFailCount = 0;

--- a/src/domains/entity/entity-class.ts
+++ b/src/domains/entity/entity-class.ts
@@ -27,7 +27,7 @@ export const ENTITY_CLASSES: Record<EntityClassName, EntityClassDef> = {
       'talk', 'quarrel', 'attack', 'heal', 'share',
       'reproduce', 'sleep', 'harvest', 'eat', 'wash',
       'deposit', 'withdraw', 'pickup', 'poop', 'clean',
-      'play', 'build_farm',
+      'play', 'build_farm', 'seek_mate',
     ]),
     emojiMap: {
       idle: '\u{1F642}',     // 🙂
@@ -48,6 +48,8 @@ export const ENTITY_CLASSES: Record<EntityClassName, EntityClassDef> = {
       clean: '\u{1F637}',    // 😷
       play: '\u{1F92A}',     // 🤪
       build_farm: '\u{1F920}',// 🤠
+      seek_mate: '\u{1F495}', // 💕
+      await_mate: '\u{1F497}',// 💗
     },
   },
   elder: {
@@ -76,6 +78,7 @@ export const ENTITY_CLASSES: Record<EntityClassName, EntityClassDef> = {
       clean: '\u{1F637}',
       play: '\u{1F92A}',
       build_farm: '\u{1F920}',
+      await_mate: '\u{1F497}',// 💗
     },
     statModifiers: { attackMult: 0.7 },
   },

--- a/src/domains/entity/types.ts
+++ b/src/domains/entity/types.ts
@@ -12,6 +12,13 @@ export enum NeedBand {
   FULL = 'full',
 }
 
+export enum Mood {
+  FRUSTRATED = 'frustrated',
+  UNHAPPY = 'unhappy',
+  CONTENT = 'content',
+  HAPPY = 'happy',
+}
+
 export interface AgentOpts {
   id: string;
   name: string;
@@ -45,4 +52,6 @@ export interface AgentOpts {
   babyMsRemaining?: number;
   entityClass?: EntityClassName;
   generation?: number;
+  matingTargetId?: string | null;
+  parentIds?: string[];
 }

--- a/src/domains/genetics/expression.ts
+++ b/src/domains/genetics/expression.ts
@@ -64,6 +64,7 @@ export function expressGenome(genes: ReadonlyArray<RawGeneEntry>): TraitSet {
   const endurance = s('RR');
   const fidelity = s('SS');
   const greed = s('UU');
+  const maternity = s('VV');
 
   // Parthenogenesis is special: boolean based on raw > 0
   const partRaw = rawSums.get('TT') ?? 0;
@@ -137,6 +138,9 @@ export function expressGenome(genes: ReadonlyArray<RawGeneEntry>): TraitSet {
     },
     greed: {
       hoardProbability: greed['hoardProbability'] ?? 0.4,
+    },
+    maternity: {
+      feedProbability: maternity['feedProbability'] ?? 0.5,
     },
   };
 }

--- a/src/domains/genetics/gene-registry.ts
+++ b/src/domains/genetics/gene-registry.ts
@@ -141,6 +141,12 @@ export const GENE_REGISTRY: ReadonlyMap<string, TraitDef> = new Map<string, Trai
       { key: 'hoardProbability', min: 0.0, default: 0.4, max: 1.0, scale: 500, inverted: false },
     ],
   }],
+  ['VV', {
+    code: 'VV', name: 'Maternity', essential: false,
+    components: [
+      { key: 'feedProbability', min: 0.0, default: 0.5, max: 1.0, scale: 500, inverted: false },
+    ],
+  }],
 ]);
 
 /**

--- a/src/domains/genetics/types.ts
+++ b/src/domains/genetics/types.ts
@@ -36,6 +36,7 @@ export interface TraitSet {
   readonly endurance: { readonly inventoryCapacity: number };
   readonly fidelity: { readonly leaveProbability: number };
   readonly greed: { readonly hoardProbability: number };
+  readonly maternity: { readonly feedProbability: number };
 }
 
 /** Definition of a single trait component's scaling */

--- a/src/domains/persistence/persistence-manager.ts
+++ b/src/domains/persistence/persistence-manager.ts
@@ -119,6 +119,8 @@ export class PersistenceManager {
       babyMsRemaining: a.babyMsRemaining,
       maxAgeTicks: a.maxAgeTicks,
       generation: a.generation,
+      matingTargetId: a.matingTargetId,
+      parentIds: a.parentIds,
       goal: a.goal,
       replanAtTick: a.replanAtTick,
       pathFailCount: a.pathFailCount,
@@ -413,11 +415,17 @@ export class PersistenceManager {
         babyMsRemaining: a.babyMsRemaining ?? 0,
         maxAgeTicks: a.maxAgeTicks,
         generation: a.generation ?? 1,
+        matingTargetId: a.matingTargetId ?? null,
+        parentIds: a.parentIds ?? [],
         goal: a.goal ?? null,
         replanAtTick: a.replanAtTick ?? 0,
       });
       // Restore pathFailCount (not in AgentOpts, set directly)
       agent.pathFailCount = a.pathFailCount ?? 0;
+      // Validate matingTargetId references an existing agent
+      if (agent.matingTargetId && !(d.agents || []).some((x: Record<string, unknown>) => x.id === agent.matingTargetId)) {
+        agent.matingTargetId = null;
+      }
       // Restore resource memory
       if (Array.isArray(a.resourceMemory)) {
         for (const [rType, entries] of a.resourceMemory as [ResourceMemoryType, IResourceMemoryEntry[]][]) {

--- a/src/domains/rendering/renderer.ts
+++ b/src/domains/rendering/renderer.ts
@@ -4,6 +4,8 @@ import type { TerrainField } from '../world/terrain-field';
 import type { World } from '../world';
 import type { DeathCause } from '../world/types';
 import type { Agent } from '../entity/agent';
+import { evaluateNeeds } from '../decision/need-evaluator';
+import { computeMood } from '../decision/mood-evaluator';
 import { Camera } from './camera';
 import { EmojiCache } from './emoji-cache';
 
@@ -499,8 +501,13 @@ export class Renderer {
       let emoji: string;
       if (agent.babyMsRemaining > 0 && (actionType === 'eat' || actionType === 'wash')) {
         emoji = IDLE_EMOJIS.babyEating;
+      } else if (AGENT_EMOJIS[actionType as string]) {
+        emoji = AGENT_EMOJIS[actionType as string];
+      } else if (agent.matingTargetId) {
+        emoji = AGENT_EMOJIS['seek_mate'] || '\u{1F495}';
       } else {
-        emoji = AGENT_EMOJIS[actionType as string] || getIdleEmoji(agent);
+        const mood = computeMood(evaluateNeeds(agent));
+        emoji = getIdleEmoji(agent, mood);
       }
 
       let offX = 0, offY = 0, angle = 0, sx = 1, sy = 1;

--- a/src/domains/simulation/agent-updater.ts
+++ b/src/domains/simulation/agent-updater.ts
@@ -4,6 +4,7 @@ import { key, manhattan, rndi, log } from '../../core/utils';
 import { findPath, findNearest, planPath } from '../../core/pathfinding';
 import type { World } from '../world/world';
 import type { Agent } from '../entity/agent';
+import { Mood } from '../entity/types';
 import { AgentFactory } from '../entity/agent-factory';
 import { FoodField } from '../world/food-field';
 import { WaterField } from '../world/water-field';
@@ -11,6 +12,8 @@ import { ActionFactory } from '../action/action-factory';
 import { ActionProcessor } from '../action/action-processor';
 import { DecisionEngine } from '../decision/decision-engine';
 import { ContextBuilder } from '../decision/context-builder';
+import { evaluateNeeds } from '../decision/need-evaluator';
+import { computeMood } from '../decision/mood-evaluator';
 
 // ── Inlined TUNE constants ──
 
@@ -571,6 +574,60 @@ function tryHarvestAdjacentWood(world: World, agent: Agent): boolean {
   return false;
 }
 
+// ── Mate consent check ──
+
+function checkMateConsent(world: World, agent: Agent, partner: Agent): boolean {
+  if (partner.health <= 0) return false;
+  if (partner.pregnancy.active) return false;
+  if (partner.entityClass === 'elder' || partner.entityClass === 'baby') return false;
+  if (partner.diseased) return false;
+  if (partner.relationships.get(agent.id) < 0.4) return false;
+  const partnerMood = computeMood(evaluateNeeds(partner));
+  if (partnerMood === Mood.UNHAPPY || partnerMood === Mood.FRUSTRATED) return false;
+  if (partner._underAttack) return false;
+  if (partner.matingTargetId) return false;
+  if (partner.action && partner.action.type !== 'sleep') return false;
+  return true;
+}
+
+// ── Mating target validation and adjacency check ──
+
+function processMatingTarget(world: World, agent: Agent): boolean {
+  if (!agent.matingTargetId) return false;
+  const partner = world.agentsById.get(agent.matingTargetId);
+
+  // Cancel conditions
+  const shouldCancel = !partner ||
+    partner.health <= 0 ||
+    (!partner.action || partner.action.type !== 'await_mate') ||
+    agent.fullness <= FULLNESS_CRITICAL_THRESHOLD;
+
+  if (shouldCancel) {
+    agent.matingTargetId = null;
+    if (partner?.action?.type === 'await_mate') partner.action = null;
+    agent.path = null;
+    return false;
+  }
+
+  const dist = manhattan(agent.cellX, agent.cellY, partner.cellX, partner.cellY);
+  if (dist === 1) {
+    // Adjacent — start reproduction
+    agent.matingTargetId = null;
+    agent.path = null;
+    // Refresh partner's await_mate so they stay put during reproduce
+    partner.action = ActionFactory.create('await_mate', partner, { targetId: agent.id });
+    tryStartAction(agent, 'reproduce', { targetId: partner.id });
+    log(world, 'reproduce', `${agent.name} reached ${partner.name} to mate`, agent.id, { targetId: partner.id });
+    return true;
+  }
+
+  // Not adjacent yet — repath if needed
+  if (!agent.path || agent.pathIdx >= agent.path.length) {
+    agentPlanPath(world, agent, partner.cellX, partner.cellY);
+  }
+  return true; // Still seeking, skip normal decisions
+}
+
 // ── Main Agent Update ──
 
 export class AgentUpdater {
@@ -596,6 +653,32 @@ export class AgentUpdater {
       if (agent.babyMsRemaining === 0 && agent.entityClass === 'baby') {
         agent.entityClass = 'adult';
         log(world, 'spawn', `${agent.name} grew up`, agent.id, {});
+      }
+    }
+
+    // Maternity feeding — adults feed adjacent babies
+    if (agent.babyMsRemaining > 0) {
+      const adjCells: [number, number][] = [
+        [agent.cellX + 1, agent.cellY], [agent.cellX - 1, agent.cellY],
+        [agent.cellX, agent.cellY + 1], [agent.cellX, agent.cellY - 1],
+      ];
+      for (const [nx, ny] of adjCells) {
+        const adjId = world.agentsByCell.get(key(nx, ny));
+        if (!adjId) continue;
+        const adult = world.agentsById.get(adjId);
+        if (!adult || adult.babyMsRemaining > 0 || adult.inventory.food <= 0) continue;
+
+        const isParent = agent.parentIds.includes(adult.id);
+        const feedChance = isParent
+          ? adult.traits.maternity.feedProbability * 0.05
+          : 0.01;
+
+        if (Math.random() < feedChance) {
+          adult.inventory.remove('food', 1);
+          agent.addFullness(15);
+          log(world, 'reproduce', `${adult.name} fed baby ${agent.name}`, adult.id, {});
+          break;
+        }
       }
     }
 
@@ -742,6 +825,11 @@ export class AgentUpdater {
           }
         }
 
+        // ── Mating target tracking (while pathfinding or idle) ──
+        if (!agent.action && processMatingTarget(world, agent)) {
+          // Agent is seeking mate — skip normal decisions
+        } else {
+
         // Vision scan
         if (!agent.action) {
           scanVision(world, agent);
@@ -751,7 +839,20 @@ export class AgentUpdater {
         if (!agent.path && !agent.action) {
           // Try the new DecisionEngine first for scored action selection
           const candidate = DecisionEngine.decide(agent, ContextBuilder.build(world, agent));
-          if (candidate && candidate.actionType !== 'sleep') {
+          if (candidate && candidate.actionType === 'seek_mate' && candidate.targetId) {
+            // Handle seek_mate: consent check, start pathfinding, partner waits
+            const partner = world.agentsById.get(candidate.targetId);
+            if (partner && checkMateConsent(world, agent, partner)) {
+              agent.matingTargetId = candidate.targetId;
+              if (partner.action?.type === 'sleep') partner.action = null;
+              if (!partner.action) {
+                partner.action = ActionFactory.create('await_mate', partner, { targetId: agent.id });
+                partner.path = null;
+              }
+              agentPlanPath(world, agent, partner.cellX, partner.cellY);
+              log(world, 'reproduce', `${agent.name} is seeking ${partner.name} as a mate`, agent.id, { targetId: partner.id });
+            }
+          } else if (candidate && candidate.actionType !== 'sleep') {
             // For social/combat actions that need a target, wire them up
             if (candidate.targetId) {
               tryStartAction(agent,candidate.actionType, { targetId: candidate.targetId });
@@ -891,6 +992,7 @@ export class AgentUpdater {
 
           } // end baby guard else
         }
+      } // end mating target else
       }
     }
 
@@ -957,6 +1059,10 @@ export class AgentUpdater {
       agent.generation,
       preg.donatedFullness
     );
+
+    // Set parent IDs for maternity feeding
+    child.parentIds = [agent.id];
+    if (preg.partnerId) child.parentIds.push(preg.partnerId);
 
     world.agents.push(child);
     world.agentsById.set(child.id, child);

--- a/src/domains/ui/ui-manager.ts
+++ b/src/domains/ui/ui-manager.ts
@@ -3,7 +3,10 @@ import { getIdleEmoji } from '../../core/utils';
 import type { LogCategory } from '../action/types';
 import type { World } from '../world';
 import type { Agent } from '../entity/agent';
+import { Mood } from '../entity/types';
 import { GENE_REGISTRY } from '../genetics/gene-registry';
+import { evaluateNeeds } from '../decision/need-evaluator';
+import { computeMood } from '../decision/mood-evaluator';
 
 const PAGE_LOAD_TIME = Date.now() - performance.now();
 
@@ -525,9 +528,19 @@ export class UIManager {
     }
     if (badge) (badge as HTMLElement).style.display = '';
 
+    const mood = computeMood(evaluateNeeds(a));
+    const moodColors: Record<string, { bg: string; fg: string; border: string }> = {
+      [Mood.HAPPY]: { bg: '#22c55e22', fg: '#22c55e', border: '#22c55e55' },
+      [Mood.CONTENT]: { bg: '#3b82f622', fg: '#3b82f6', border: '#3b82f655' },
+      [Mood.UNHAPPY]: { bg: '#eab30822', fg: '#eab308', border: '#eab30855' },
+      [Mood.FRUSTRATED]: { bg: '#ef444422', fg: '#ef4444', border: '#ef444455' },
+    };
+    const mc = moodColors[mood] ?? moodColors[Mood.CONTENT];
+    const moodEmoji = mood === Mood.HAPPY ? '\u{1F600}' : mood === Mood.CONTENT ? '\u{1F642}' : mood === Mood.UNHAPPY ? '\u{1F629}' : '\u{1F621}';
+
     const actionType = a.action?.type;
     const emoji =
-      AGENT_EMOJIS[actionType as string] || getIdleEmoji(a);
+      AGENT_EMOJIS[actionType as string] || getIdleEmoji(a, mood);
     const factionColor = a.factionId
       ? world.factions.get(a.factionId)?.color || '#888'
       : null;
@@ -556,6 +569,11 @@ export class UIManager {
             }
             ${a.diseased
               ? `<span class="badge-action" style="background:#4ade8022;color:#4ade80;border-color:#4ade8055">\u{1F922} DISEASED</span>`
+              : ''
+            }
+            <span class="badge-action" style="background:${mc.bg};color:${mc.fg};border-color:${mc.border}">${moodEmoji} ${mood.toUpperCase()}</span>
+            ${a.matingTargetId
+              ? `<span class="badge-action" style="background:#f9a8d422;color:#f9a8d4;border-color:#f9a8d455">\u{1F495} SEEKING MATE</span>`
               : ''
             }
             ${actionType
@@ -657,6 +675,7 @@ export class UIManager {
           ${traitCell('END', a.traits.endurance.inventoryCapacity.toFixed(0), a.traits.endurance.inventoryCapacity, 'RR', 'Endurance — Inventory capacity')}
           ${traitCell('MAT', (a.traits.maturity.babyDurationMs / 1000).toFixed(0) + 's', a.traits.maturity.babyDurationMs, 'QQ', 'Maturity — Baby stage duration (lower = matures faster)')}
           ${traitCell('GRD', a.traits.greed.hoardProbability.toFixed(2), a.traits.greed.hoardProbability, 'UU', 'Greed — Probability of opportunistic resource hoarding')}
+          ${traitCell('MTN', a.traits.maternity.feedProbability.toFixed(2), a.traits.maternity.feedProbability, 'VV', 'Maternity — Probability of feeding nearby babies')}
           ${a.traits.parthenogenesis.canSelfReproduce ? '<div title="Parthenogenesis — Can reproduce without a partner" style="color:#f9a8d4;cursor:help">ASEXUAL</div>' : ''}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- **Mood system**: FRUSTRATED/UNHAPPY/CONTENT/HAPPY derived from need bands each tick; color-coded mood badge in inspector; mood-based idle emojis; mood gates/boosts reproduction, building, and combat
- **Mate seeking**: Happy sexual agents pathfind to partners within vision range (💕); consenting partner waits in place (💗); persists through mood dips; cancels on critical hunger/attack/timeout
- **Maternity gene (VV)**: feedProbability now active — parents feed adjacent babies at feedProbability×5%/tick; non-parents at 1%/tick; parentIds tracked at birth; MTN shown in inspector traits
- **Misc**: reproduce cancels on critical hunger (fullness ≤ 20); await_mate exempt from low-energy cancellation

## Test plan

- [ ] Click an agent — verify mood badge appears (color-coded)
- [ ] Observe happy sexual agents get 💕 emoji while pathfinding to a partner
- [ ] Observe partners waiting with 💗 emoji
- [ ] Confirm reproduction triggers once initiator is adjacent
- [ ] Confirm babies near parents gain fullness over time (check logs)
- [ ] Verify reproduce cancels when agent reaches critical hunger mid-action
- [ ] Save/load — verify mood and parentIds survive

🤖 Generated with [Claude Code](https://claude.ai/claude-code)