### PR TITLE
feat: Reset world button (#30)

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,6 +323,53 @@
         opacity: 0.4;
         cursor: not-allowed;
       }
+      .btn-reset {
+        background: #dc2626;
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        padding: 10px 8px;
+        font-size: 12px;
+        font-weight: 800;
+        letter-spacing: 0.5px;
+        cursor: pointer;
+        transition: all 0.2s;
+        box-shadow: none;
+        display: none;
+      }
+      .btn-reset:hover {
+        background: #ef4444;
+      }
+      #resetModal {
+        background: var(--panel);
+        color: var(--text);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 24px;
+        max-width: 340px;
+        width: 90vw;
+      }
+      #resetModal::backdrop {
+        background: rgba(0,0,0,0.6);
+      }
+      #resetModal p {
+        margin: 0 0 20px;
+        font-size: 13px;
+        line-height: 1.5;
+        color: var(--muted);
+      }
+      #resetModal h2 {
+        margin: 0 0 10px;
+        font-size: 15px;
+        font-weight: 800;
+        letter-spacing: 1px;
+        color: var(--text);
+      }
+      .reset-modal-actions {
+        display: flex;
+        gap: 10px;
+        justify-content: flex-end;
+      }
       .btn-action {
         background: var(--panel-2);
         color: var(--text);
@@ -948,6 +995,7 @@
         <div class="panel-body">
           <div class="action-buttons">
             <button id="btnStart" class="btn-start">&#9654; START</button>
+            <button id="btnReset" class="btn-reset">&#8635; RESET</button>
             <button id="btnPause" class="btn-action" disabled>&#10074;&#10074; PAUSE</button>
             <button id="btnResume" class="btn-action" disabled>&#9654;&#9654; RESUME</button>
           </div>
@@ -1274,5 +1322,13 @@
         });
       });
     </script>
+  <dialog id="resetModal">
+    <h2>RESET SIMULATION</h2>
+    <p>This will permanently erase the current world, all agents, and the autosave. This cannot be undone.</p>
+    <div class="reset-modal-actions">
+      <button id="btnResetCancel" class="btn-action">Cancel</button>
+      <button id="btnResetConfirm" class="btn-reset" style="display:block">Reset</button>
+    </div>
+  </dialog>
   </body>
 </html>

--- a/src/domains/persistence/persistence-manager.ts
+++ b/src/domains/persistence/persistence-manager.ts
@@ -7,7 +7,7 @@ import { Agent } from '../entity/agent';
 import { Genome } from '../genetics';
 import { Faction, FactionManager } from '../faction';
 
-const VERSION = '4.1.2';
+const VERSION = '4.1.3';
 
 // Inlined TUNE constants
 const FARM_MAX_SPAWNS = 12;

--- a/src/domains/ui/controls.ts
+++ b/src/domains/ui/controls.ts
@@ -145,7 +145,8 @@ export class Controls {
       seedEnvironment(world);
       spawnAgents(Number(ranges.rngAgents?.value || 20));
       world.running = true;
-      if (buttons.btnStart) buttons.btnStart.disabled = true;
+      if (buttons.btnStart) buttons.btnStart.style.display = 'none';
+      if (buttons.btnReset) buttons.btnReset.style.display = '';
       if (buttons.btnPause) buttons.btnPause.disabled = false;
       if (buttons.btnResume) buttons.btnResume.disabled = true;
       if (ranges.rngAgents) ranges.rngAgents.disabled = true;
@@ -172,6 +173,60 @@ export class Controls {
       world.running = true;
       if (buttons.btnPause) buttons.btnPause.disabled = false;
       if (buttons.btnResume) buttons.btnResume.disabled = true;
+    });
+
+    const resetModal = document.querySelector<HTMLDialogElement>('#resetModal');
+    const btnResetConfirm = document.querySelector<HTMLButtonElement>('#btnResetConfirm');
+    const btnResetCancel = document.querySelector<HTMLButtonElement>('#btnResetCancel');
+
+    buttons.btnReset?.addEventListener('click', () => {
+      resetModal?.showModal();
+    });
+    btnResetCancel?.addEventListener('click', () => {
+      resetModal?.close();
+    });
+    btnResetConfirm?.addEventListener('click', () => {
+      resetModal?.close();
+      // Stop simulation and clear all state
+      world.running = false;
+      world.grid.clear();
+      world.agents.length = 0;
+      world.agentsById.clear();
+      world.agentsByCell.clear();
+      world.factions.clear();
+      world.familyRegistry.clear();
+      world.flags.clear();
+      world.flagCells.clear();
+      world.obstacles.clear();
+      world.farms.clear();
+      world.foodBlocks.clear();
+      world.waterBlocks.clear();
+      world.treeBlocks.clear();
+      world.seedlings.clear();
+      world.lootBags.clear();
+      world.poopBlocks.clear();
+      world.saltWaterBlocks.clear();
+      world.eggs.clear();
+      world.clouds = [];
+      world._nextCloudSpawnMs = 0;
+      world.tick = 0;
+      world.totalBirths = 0;
+      world.totalDeaths = 0;
+      world.selectedId = null;
+      world.log = new RingLog(200);
+      world.activeLogCats = new Set(LOG_CATS);
+      UIManager.setupLogFilters(world, dom.logFilters, doRenderLog);
+      // Clear autosave so page refresh also starts fresh
+      PersistenceManager.clearAutosave();
+      // Restore controls to pre-start state
+      if (buttons.btnReset) buttons.btnReset.style.display = 'none';
+      if (buttons.btnStart) buttons.btnStart.style.display = '';
+      if (buttons.btnPause) buttons.btnPause.disabled = true;
+      if (buttons.btnResume) buttons.btnResume.disabled = true;
+      if (ranges.rngAgents) ranges.rngAgents.disabled = false;
+      if (nums.numAgents) nums.numAgents.disabled = false;
+      if (ranges.rngWorldSize) ranges.rngWorldSize.disabled = false;
+      if (nums.numWorldSize) nums.numWorldSize.disabled = false;
     });
 
     buttons.btnSpawnCrop?.addEventListener('click', () => {

--- a/src/domains/ui/ui-manager.ts
+++ b/src/domains/ui/ui-manager.ts
@@ -100,6 +100,7 @@ export interface DomRefs {
   hud: HTMLElement | null;
   buttons: {
     btnStart: HTMLButtonElement | null;
+    btnReset: HTMLButtonElement | null;
     btnPause: HTMLButtonElement | null;
     btnResume: HTMLButtonElement | null;
     btnSpawnCrop: HTMLButtonElement | null;
@@ -176,6 +177,7 @@ export class UIManager {
       hud: qs('#hud'),
       buttons: {
         btnStart: qs('#btnStart') as HTMLButtonElement | null,
+        btnReset: qs('#btnReset') as HTMLButtonElement | null,
         btnPause: qs('#btnPause') as HTMLButtonElement | null,
         btnResume: qs('#btnResume') as HTMLButtonElement | null,
         btnSpawnCrop: qs('#btnSpawnCrop') as HTMLButtonElement | null,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { TICK_MS, CELL_PX } from './core/constants';
 
-const VERSION = '4.1.2';
+const VERSION = '4.1.3';
 import { World } from './domains/world';
 import { Camera } from './domains/rendering/camera';
 import { Renderer } from './domains/rendering/renderer';


### PR DESCRIPTION
## Summary

- Red **RESET** button appears in place of the START button once the simulation is running
- Clicking RESET opens a native `<dialog>` confirmation modal (destructive/irreversible warning)
- Confirming clears all world state (agents, factions, blocks, clouds, terrain, etc.), erases the autosave from `localStorage`, and restores the UI to its pre-start state (START button re-appears, world-size/agent-count controls re-enabled)
- Cancelling dismisses the modal with no effect

## Files changed

- `index.html` — `.btn-reset` styles, `#btnReset` button, `#resetModal` dialog
- `src/domains/ui/ui-manager.ts` — `btnReset` added to `DomRefs` interface and `bindDom()`
- `src/domains/ui/controls.ts` — show/hide logic on start; reset handler with modal wiring

## Test plan

- [ ] Click START → START button hides, red RESET button appears
- [ ] Click RESET → confirmation modal opens
- [ ] Click Cancel → modal closes, simulation continues unchanged
- [ ] Click Reset in modal → world clears, RESET hides, START re-appears and is clickable
- [ ] Refresh page after reset → no autosave loads, blank start screen

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)