### PR TITLE
feat: reset world button + version 4.1.4

### DIFF
--- a/src/domains/persistence/persistence-manager.ts
+++ b/src/domains/persistence/persistence-manager.ts
@@ -7,7 +7,7 @@ import { Agent } from '../entity/agent';
 import { Genome } from '../genetics';
 import { Faction, FactionManager } from '../faction';
 
-const VERSION = '4.1.3';
+const VERSION = '4.1.4';
 
 // Inlined TUNE constants
 const FARM_MAX_SPAWNS = 12;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { TICK_MS, CELL_PX } from './core/constants';
 
-const VERSION = '4.1.3';
+const VERSION = '4.1.4';
 import { World } from './domains/world';
 import { Camera } from './domains/rendering/camera';
 import { Renderer } from './domains/rendering/renderer';


### PR DESCRIPTION
## Summary
- Fix reset button not appearing after simulation starts (was setting `display: ''` which fell back to CSS `display: none`)
- Bump version to 4.1.4

## Test plan
- [ ] Click START — verify the RESET button appears and START button hides
- [ ] Click RESET and confirm — verify the START button returns and RESET button hides

🤖 Generated with [Claude Code](https://claude.com/claude-code)