### PR TITLE
fix: immortal agents near flags (#38)

### DIFF
--- a/src/domains/simulation/agent-updater.ts
+++ b/src/domains/simulation/agent-updater.ts
@@ -52,7 +52,6 @@ const FARM_WOOD_COST = 3;
 const FARM_ENERGY_COST = 6;
 
 const MANDATORY_SLEEP_THRESHOLD = 20;
-const CRITICAL_HEALTH_PCT = 0.3;
 const CRITICAL_FULLNESS_THRESHOLD = 20;
 const CRITICAL_HYGIENE_THRESHOLD = 20;
 
@@ -140,18 +139,7 @@ function interactionConsider(world: World, agent: Agent): void {
 
   // 2. Under attack — handled by DecisionEngine (flee/retaliate)
 
-  // 3. Critical health — seek faction flag for aura healing
-  if (agent.health < agent.maxHealth * CRITICAL_HEALTH_PCT) {
-    if (agent.factionId) {
-      const flag = world.flags.get(agent.factionId);
-      if (flag && manhattan(agent.cellX, agent.cellY, flag.x, flag.y) > 2) {
-        agentPlanPath(world, agent, flag.x, flag.y);
-        if (agent.path && agent.path.length > 0) return;
-      }
-    }
-  }
-
-  // 4. Critical fullness
+  // 3. Critical fullness
   if (agent.fullness < CRITICAL_FULLNESS_THRESHOLD) {
     if (agent.inventory.food > 0) {
       tryStartAction(agent, 'eat');

--- a/src/domains/simulation/simulation-engine.ts
+++ b/src/domains/simulation/simulation-engine.ts
@@ -9,8 +9,6 @@ import { AgentUpdater } from './agent-updater';
 
 // ── Inlined TUNE constants ──
 
-const HEAL_AURA_RADIUS = 4;
-const HEAL_AURA_PER_TICK = 3.75;
 const LOOT_BAG_DECAY_MS = 30000;
 
 const DISEASE_SPREAD_CHANCE = 0.03;
@@ -32,18 +30,6 @@ export class SimulationEngine {
   }
   static hasPoopNearby(world: World, x: number, y: number, radius: number): boolean {
     return Spawner.hasPoopNearby(world, x, y, radius);
-  }
-
-  // ── Post-tick: Flag healing aura ──
-
-  private static _applyFlagHealing(world: World): void {
-    for (const agent of world.agents) {
-      if (!agent.factionId) continue;
-      const flag = world.flags.get(agent.factionId);
-      if (!flag) continue;
-      const d = Math.abs(agent.cellX - flag.x) + Math.abs(agent.cellY - flag.y);
-      if (d <= HEAL_AURA_RADIUS) agent.healBy(HEAL_AURA_PER_TICK);
-    }
   }
 
   // ── Post-tick: Disease spread ──
@@ -75,7 +61,7 @@ export class SimulationEngine {
     const removedIds: string[] = [];
     const now = performance.now();
     world.agents = world.agents.filter((a) => {
-      if (a.health <= 0) {
+      if (a.health <= 0 || a.ageTicks >= a.maxAgeTicks) {
         // Inline loot bag drop on death
         if (a.inventoryTotal() > 0) {
           const inv = { food: a.inventory.food, water: a.inventory.water, wood: a.inventory.wood };
@@ -209,7 +195,6 @@ export class SimulationEngine {
 
     // ── Post-tick ──
     if (world.tick % 4 === 0) FactionManager.reconcile(world);
-    SimulationEngine._applyFlagHealing(world);
     SimulationEngine._tickDiseaseSpread(world);
     SimulationEngine._cleanDead(world);
   }


### PR DESCRIPTION
## Summary

- Removes the flag healing aura (`_applyFlagHealing`) and its constants — flag healing is no longer needed and was the root cause of this bug
- Removes the critical-health flag-seeking behavior that directed agents toward flags for healing
- Fixes `_cleanDead` to remove agents where `ageTicks >= maxAgeTicks` regardless of current health, so no post-tick effect can resurrect a fatally aged agent

## Root cause

The tick order was:
1. `AgentUpdater.update` → sets `health = 0` when `ageTicks >= maxAgeTicks`
2. `_applyFlagHealing` → restores 3.75 HP to agents near their faction flag
3. `_cleanDead` → sees `health > 0`, agent survives

## Test plan

- [ ] Run simulation and observe agents die when they reach max age even while standing on/near a flag
- [ ] Confirm no agents exceed their `maxAgeTicks` and remain alive
- [ ] Verify the death log entry still appears correctly ("died of old age")
- [ ] Confirm faction flag resource storage (deposit/withdraw) still works — only the healing aura was removed

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)