### PR TITLE
feat: v4.2 Phase 2 — pregnancy transfer mechanic

### DIFF
--- a/src/domains/action/effects/reproduce-effects.ts
+++ b/src/domains/action/effects/reproduce-effects.ts
@@ -1,4 +1,5 @@
-import { manhattan, log } from '../../../core/utils';
+import { key, manhattan, log } from '../../../core/utils';
+import { TUNE } from '../../../core/tuning';
 import type { Agent } from '../../entity/agent';
 import type { World } from '../../world/world';
 import { AgentFactory } from '../../entity/agent-factory';
@@ -7,7 +8,6 @@ import { crossover } from '../../genetics/crossover';
 import { mutate } from '../../genetics/mutation';
 import { Genome } from '../../genetics/genome';
 import { isViable } from '../../genetics/viability';
-import { TUNE } from '../../../core/tuning';
 
 export function onReproduceComplete(world: World, agent: Agent, target: Agent | undefined): void {
   // Asexual reproduction (parthenogenesis)
@@ -19,29 +19,14 @@ export function onReproduceComplete(world: World, agent: Agent, target: Agent | 
   if (!target || target.health <= 0) return;
   if (manhattan(agent.cellX, agent.cellY, target.cellX, target.cellY) !== 1) return;
 
-  const spots: [number, number][] = [
-    [agent.cellX + 1, agent.cellY],
-    [agent.cellX - 1, agent.cellY],
-    [agent.cellX, agent.cellY + 1],
-    [agent.cellX, agent.cellY - 1],
-  ];
-  const free = spots.find(([x, y]) => !world.grid.isBlocked(x, y));
-  if (!free) return;
-
-  // Energy + fullness costs
+  // Energy costs paid up front by both parents
   agent.drainEnergy(TUNE.reproduce.energyCost);
   target.drainEnergy(TUNE.reproduce.energyCost);
 
-  const [donateMin, donateMax] = TUNE.pregnancy.v4FullnessDonateRange;
-  const p1Donate = Math.min(agent.fullness, donateMin + Math.random() * (donateMax - donateMin));
-  const p2Donate = Math.min(target.fullness, donateMin + Math.random() * (donateMax - donateMin));
-  agent.drainFullness(p1Donate);
-  target.drainFullness(p2Donate);
+  // DNA: crossover then mutate, using average Volatility of both parents
+  const mutationRate = (agent.traits.volatility.mutationRate + target.traits.volatility.mutationRate) / 2;
+  const childDna = mutate(crossover(agent.genome.dna, target.genome.dna), mutationRate);
 
-  // DNA: crossover then mutate (v4 path uses TUNE.mutation.baseRate)
-  const childDna = mutate(crossover(agent.genome.dna, target.genome.dna));
-
-  // Check viability
   const childGenome = new Genome(childDna);
   if (!isViable(childGenome.traits, childGenome.genes, childGenome.dna)) {
     log(world, 'reproduce', `${agent.name} had a stillborn child`, agent.id, {});
@@ -49,55 +34,169 @@ export function onReproduceComplete(world: World, agent: Agent, target: Agent | 
     return;
   }
 
-  // Initiator is the carrier and lineage holder
   const familyName = agent.familyName;
-  const [x, y] = free;
+  const factionId = resolveFactionId(agent, target);
+  const hasAG = agent.genome.hasGeneCode('AG');
+  const gestationMs = agent.traits.pregnancy.gestationMs;
 
-  // Faction: inherit from initiator, or 50/50 if both have factions
-  let factionId: string | null = null;
-  const pa = agent.factionId || null;
-  const pb = target.factionId || null;
-  if (pa && pb) factionId = Math.random() < 0.5 ? pa : pb;
-  else factionId = pa || pb;
+  if (hasAG && gestationMs > 0) {
+    // v4.2 path: gradual need-transfer gestation
+    agent.pregnancy.start({
+      childDna,
+      childFamilyName: familyName,
+      childFactionId: factionId,
+      partnerId: target.id,
+      useTransferMechanic: true,
+      transferRate: TUNE.pregnancy.needTransferRate,
+      gestationStartTick: world.tick,
+    });
+    world.events.emit('pregnancy:started', { agentId: agent.id });
+    log(world, 'reproduce', `${agent.name} & ${target.name} are expecting`, agent.id, { targetId: target.id });
 
-  // Start pregnancy on the initiator
-  const babyDuration = childGenome.traits.maturity.babyDurationMs;
-  const pregnancyDuration = babyDuration * TUNE.pregnancy.v4DurationMult;
-  const totalDonated = p1Donate + p2Donate;
-  agent.pregnancy.start(childDna, pregnancyDuration, familyName, factionId, target.id, totalDonated);
+  } else if (hasAG && gestationMs <= 0) {
+    // AG gene present but zero expression: instant birth, all child needs at zero.
+    // Child must be fed immediately or it will die of starvation.
+    instantBirth(world, agent, childDna, familyName, factionId, target.id);
 
-  world.events.emit('pregnancy:started', { agentId: agent.id, duration: pregnancyDuration });
-  log(world, 'reproduce', `${agent.name} & ${target.name} are expecting`, agent.id, { targetId: target.id });
+  } else {
+    // v4 fallback: countdown timer with fullness donation from both parents
+    const [donateMin, donateMax] = TUNE.pregnancy.v4FullnessDonateRange;
+    const p1Donate = Math.min(agent.fullness, donateMin + Math.random() * (donateMax - donateMin));
+    const p2Donate = Math.min(target.fullness, donateMin + Math.random() * (donateMax - donateMin));
+    agent.drainFullness(p1Donate);
+    target.drainFullness(p2Donate);
+
+    const babyDuration = childGenome.traits.maturity.babyDurationMs;
+    agent.pregnancy.start({
+      childDna,
+      childFamilyName: familyName,
+      childFactionId: factionId,
+      partnerId: target.id,
+      useTransferMechanic: false,
+      donatedFullness: p1Donate + p2Donate,
+      remainingMs: babyDuration * TUNE.pregnancy.v4DurationMult,
+    });
+    world.events.emit('pregnancy:started', { agentId: agent.id, duration: babyDuration * TUNE.pregnancy.v4DurationMult });
+    log(world, 'reproduce', `${agent.name} & ${target.name} are expecting`, agent.id, { targetId: target.id });
+  }
 }
 
 function reproduceAsexual(world: World, agent: Agent): void {
+  agent.drainEnergy(TUNE.reproduce.energyCost);
+
+  // Asexual: mutation rate from agent's own Volatility
+  const childDna = mutate(agent.genome.dna, agent.traits.volatility.mutationRate);
+  const childGenome = new Genome(childDna);
+  if (!isViable(childGenome.traits, childGenome.genes, childGenome.dna)) {
+    log(world, 'reproduce', `${agent.name} had a stillborn child`, agent.id, {});
+    world.events.emit('agent:stillborn', { parentId: agent.id });
+    return;
+  }
+
+  const factionId = agent.factionId;
+  const hasAG = agent.genome.hasGeneCode('AG');
+  const gestationMs = agent.traits.pregnancy.gestationMs;
+
+  if (hasAG && gestationMs > 0) {
+    agent.pregnancy.start({
+      childDna,
+      childFamilyName: agent.familyName,
+      childFactionId: factionId,
+      partnerId: null,
+      useTransferMechanic: true,
+      transferRate: TUNE.pregnancy.needTransferRate,
+      gestationStartTick: world.tick,
+    });
+    world.events.emit('pregnancy:started', { agentId: agent.id });
+    log(world, 'reproduce', `${agent.name} is expecting (asexual)`, agent.id, {});
+
+  } else if (hasAG && gestationMs <= 0) {
+    instantBirth(world, agent, childDna, agent.familyName, factionId, null);
+
+  } else {
+    // v4 fallback
+    const [donateMin, donateMax] = TUNE.pregnancy.v4FullnessDonateRange;
+    const p1Donate = Math.min(agent.fullness, donateMin + Math.random() * (donateMax - donateMin));
+    agent.drainFullness(p1Donate);
+
+    const babyDuration = childGenome.traits.maturity.babyDurationMs;
+    agent.pregnancy.start({
+      childDna,
+      childFamilyName: agent.familyName,
+      childFactionId: factionId,
+      partnerId: null,
+      useTransferMechanic: false,
+      donatedFullness: p1Donate,
+      remainingMs: babyDuration * TUNE.pregnancy.v4DurationMult,
+    });
+    world.events.emit('pregnancy:started', { agentId: agent.id, duration: babyDuration * TUNE.pregnancy.v4DurationMult });
+    log(world, 'reproduce', `${agent.name} is expecting (asexual)`, agent.id, {});
+  }
+}
+
+/**
+ * AG gene present but gestationMs = 0: child is born immediately with all
+ * needs at zero. It must be fed immediately or it will die.
+ */
+function instantBirth(
+  world: World,
+  parent: Agent,
+  childDna: string,
+  familyName: string,
+  factionId: string | null,
+  partnerId: string | null
+): void {
   const spots: [number, number][] = [
-    [agent.cellX + 1, agent.cellY],
-    [agent.cellX - 1, agent.cellY],
-    [agent.cellX, agent.cellY + 1],
-    [agent.cellX, agent.cellY - 1],
+    [parent.cellX + 1, parent.cellY],
+    [parent.cellX - 1, parent.cellY],
+    [parent.cellX, parent.cellY + 1],
+    [parent.cellX, parent.cellY - 1],
   ];
   const free = spots.find(([x, y]) => !world.grid.isBlocked(x, y));
   if (!free) return;
 
-  agent.drainEnergy(TUNE.reproduce.energyCost);
-  const [donateMinA, donateMaxA] = TUNE.pregnancy.v4FullnessDonateRange;
-  const p1Donate = Math.min(agent.fullness, donateMinA + Math.random() * (donateMaxA - donateMinA));
-  agent.drainFullness(p1Donate);
+  const [cx, cy] = free;
+  const child = AgentFactory.createChild(cx, cy, childDna, familyName, factionId, parent.generation, 0);
 
-  // No crossover, just mutate
-  const childDna = mutate(agent.genome.dna);
-  const childGenome = new Genome(childDna);
-  if (!isViable(childGenome.traits, childGenome.genes, childGenome.dna)) {
-    log(world, 'reproduce', `${agent.name} had a stillborn child`, agent.id, {});
-    world.events.emit('agent:stillborn', { parentId: agent.id });
-    return;
+  // All needs at zero — must be fed or it dies
+  child.needs.fullness    = 0;
+  child.needs.hygiene     = 0;
+  child.needs.social      = 0;
+  child.needs.inspiration = 0;
+
+  child.parentIds = [parent.id];
+  if (partnerId) child.parentIds.push(partnerId);
+
+  world.agents.push(child);
+  world.agentsById.set(child.id, child);
+  world.agentsByCell.set(key(cx, cy), child.id);
+  world.totalBirths++;
+  world.birthTimestamps.push(performance.now());
+  world.familyRegistry.registerBirth(child.familyName, child.generation);
+
+  const parentBond = 0.8;
+  child.relationships.set(parent.id, parentBond);
+  parent.relationships.adjust(child.id, parentBond);
+  if (partnerId) {
+    const partner = world.agentsById.get(partnerId);
+    if (partner) {
+      child.relationships.set(partnerId, parentBond);
+      partner.relationships.adjust(child.id, parentBond);
+    }
   }
 
-  const babyDuration = childGenome.traits.maturity.babyDurationMs;
-  const pregnancyDuration = babyDuration * TUNE.pregnancy.v4DurationMult;
-  agent.pregnancy.start(childDna, pregnancyDuration, agent.familyName, agent.factionId, null, p1Donate);
+  if (child.factionId) {
+    const faction = world.factions.get(child.factionId);
+    if (faction) faction.members.add(child.id);
+  }
 
-  world.events.emit('pregnancy:started', { agentId: agent.id, duration: pregnancyDuration });
-  log(world, 'reproduce', `${agent.name} is expecting (asexual)`, agent.id, {});
+  world.events.emit('agent:born', { child, parent1Id: parent.id, parent2Id: partnerId });
+  log(world, 'reproduce', `${parent.name} gave birth to ${child.name} ${child.familyName} (instant)`, parent.id, { childId: child.id });
+}
+
+function resolveFactionId(agent: Agent, partner: Agent): string | null {
+  const pa = agent.factionId || null;
+  const pb = partner.factionId || null;
+  if (pa && pb) return Math.random() < 0.5 ? pa : pb;
+  return pa || pb;
 }

--- a/src/domains/entity/components/pregnancy.ts
+++ b/src/domains/entity/components/pregnancy.ts
@@ -1,30 +1,99 @@
+import { TUNE } from '../../../core/tuning';
+
+export interface PregnancyStartOpts {
+  childDna: string;
+  childFamilyName: string;
+  childFactionId: string | null;
+  partnerId: string | null;
+  /** True: v4.2 gradual need-transfer gestation. False: v4 countdown timer. */
+  useTransferMechanic: boolean;
+  // v4.2 transfer mechanic fields
+  transferRate?: number;
+  gestationStartTick?: number;
+  // v4 fallback fields
+  donatedFullness?: number;
+  remainingMs?: number;
+}
+
 export class PregnancyState {
+  // ── Shared fields (both paths) ──
   active = false;
-  remainingMs = 0;
   childDna: string | null = null;
   childFamilyName: string | null = null;
   childFactionId: string | null = null;
   partnerId: string | null = null;
+
+  // ── v4 fallback fields ──
+  remainingMs = 0;
   donatedFullness = 0;
 
-  start(dna: string, durationMs: number, familyName: string, factionId: string | null, partnerId?: string | null, donatedFullness?: number): void {
+  // ── v4.2 transfer mechanic fields ──
+  useTransferMechanic = false;
+  childNeeds = { fullness: 0, hygiene: 0, social: 0, inspiration: 0 };
+  /** Per-tick rate at which child needs fill (and parent needs drain). */
+  transferRate = 0;
+  gestationStartTick = 0;
+
+  start(opts: PregnancyStartOpts): void {
     this.active = true;
-    this.remainingMs = durationMs;
-    this.childDna = dna;
-    this.childFamilyName = familyName;
-    this.childFactionId = factionId;
-    this.partnerId = partnerId ?? null;
-    this.donatedFullness = donatedFullness ?? 0;
+    this.childDna = opts.childDna;
+    this.childFamilyName = opts.childFamilyName;
+    this.childFactionId = opts.childFactionId;
+    this.partnerId = opts.partnerId;
+    this.useTransferMechanic = opts.useTransferMechanic;
+
+    if (opts.useTransferMechanic) {
+      this.transferRate = opts.transferRate ?? TUNE.pregnancy.needTransferRate;
+      this.gestationStartTick = opts.gestationStartTick ?? 0;
+      this.childNeeds = { fullness: 0, hygiene: 0, social: 0, inspiration: 0 };
+      // v4 fallback fields unused on this path
+      this.remainingMs = 0;
+      this.donatedFullness = 0;
+    } else {
+      this.remainingMs = opts.remainingMs ?? 0;
+      this.donatedFullness = opts.donatedFullness ?? 0;
+      // v4.2 fields unused on this path
+      this.transferRate = 0;
+      this.gestationStartTick = 0;
+      this.childNeeds = { fullness: 0, hygiene: 0, social: 0, inspiration: 0 };
+    }
   }
 
-  /** Tick the pregnancy timer. Returns true when birth occurs. */
+  /**
+   * Per-tick transfer step (v4.2 path only).
+   * Increases each child need by `transferRate` and returns how much
+   * was drained from each of the parent's needs.
+   */
+  tickTransfer(): { fullnessDrained: number; hygieneDrained: number; socialDrained: number; inspirationDrained: number } {
+    const r = this.transferRate;
+    this.childNeeds.fullness    = Math.min(100, this.childNeeds.fullness    + r);
+    this.childNeeds.hygiene     = Math.min(100, this.childNeeds.hygiene     + r);
+    this.childNeeds.social      = Math.min(100, this.childNeeds.social      + r);
+    this.childNeeds.inspiration = Math.min(100, this.childNeeds.inspiration + r);
+    return {
+      fullnessDrained:    r,
+      hygieneDrained:     r,
+      socialDrained:      r,
+      inspirationDrained: r,
+    };
+  }
+
+  /** True when all child needs have reached the completion threshold (v4.2 path). */
+  isReadyForBirth(): boolean {
+    const t = TUNE.pregnancy.completionThreshold;
+    return (
+      this.childNeeds.fullness    >= t &&
+      this.childNeeds.hygiene     >= t &&
+      this.childNeeds.social      >= t &&
+      this.childNeeds.inspiration >= t
+    );
+  }
+
+  /** Tick the v4 countdown timer. Returns true when birth occurs. */
   tick(dtMs: number): boolean {
     if (!this.active) return false;
     this.remainingMs -= dtMs;
-    if (this.remainingMs <= 0) {
-      return true;
-    }
-    return false;
+    return this.remainingMs <= 0;
   }
 
   clear(): void {
@@ -35,5 +104,9 @@ export class PregnancyState {
     this.childFactionId = null;
     this.partnerId = null;
     this.donatedFullness = 0;
+    this.useTransferMechanic = false;
+    this.childNeeds = { fullness: 0, hygiene: 0, social: 0, inspiration: 0 };
+    this.transferRate = 0;
+    this.gestationStartTick = 0;
   }
 }

--- a/src/domains/persistence/persistence-manager.ts
+++ b/src/domains/persistence/persistence-manager.ts
@@ -432,16 +432,23 @@ export class PersistenceManager {
           agent.resourceMemory.set(rType, entries ?? []);
         }
       }
-      // Restore pregnancy state
+      // Restore pregnancy state (v4 and v4.2 save formats)
       if (a.pregnancy && a.pregnancy.childDna) {
-        agent.pregnancy.start(
-          a.pregnancy.childDna,
-          a.pregnancy.remainingMs ?? 0,
-          a.pregnancy.childFamilyName ?? agent.familyName,
-          a.pregnancy.childFactionId ?? null,
-          a.pregnancy.partnerId ?? null,
-          a.pregnancy.donatedFullness ?? 0
-        );
+        const useTransfer = !!(a.pregnancy.useTransferMechanic);
+        agent.pregnancy.start({
+          childDna:         a.pregnancy.childDna,
+          childFamilyName:  a.pregnancy.childFamilyName ?? agent.familyName,
+          childFactionId:   a.pregnancy.childFactionId ?? null,
+          partnerId:        a.pregnancy.partnerId ?? null,
+          useTransferMechanic: useTransfer,
+          remainingMs:      a.pregnancy.remainingMs ?? 0,
+          donatedFullness:  a.pregnancy.donatedFullness ?? 0,
+          transferRate:     a.pregnancy.transferRate ?? 0,
+          gestationStartTick: a.pregnancy.gestationStartTick ?? 0,
+        });
+        if (useTransfer && a.pregnancy.childNeeds) {
+          agent.pregnancy.childNeeds = { ...a.pregnancy.childNeeds };
+        }
       }
 
       world.agents.push(agent);

--- a/src/domains/simulation/agent-updater.ts
+++ b/src/domains/simulation/agent-updater.ts
@@ -663,7 +663,7 @@ export class AgentUpdater {
       }
     }
 
-    // Pregnancy timer
+    // Pregnancy tick (miscarriage checks shared by both paths)
     if (agent.pregnancy.active) {
       // Miscarriage: starvation ends pregnancy immediately
       if (agent.fullness <= 0) {
@@ -681,7 +681,19 @@ export class AgentUpdater {
           log(world, 'reproduce', `${agent.name} lost the pregnancy (illness)`, agent.id, {});
           world.events.emit('pregnancy:miscarriage', { agentId: agent.id, cause: 'disease' });
         }
+      } else if (agent.pregnancy.useTransferMechanic) {
+        // v4.2: per-tick need transfer from parent to child
+        const drained = agent.pregnancy.tickTransfer();
+        agent.drainFullness(drained.fullnessDrained);
+        agent.needs.hygiene     = Math.max(0, agent.needs.hygiene     - drained.hygieneDrained);
+        agent.needs.social      = Math.max(0, agent.needs.social      - drained.socialDrained);
+        agent.needs.inspiration = Math.max(0, agent.needs.inspiration - drained.inspirationDrained);
+
+        if (agent.pregnancy.isReadyForBirth()) {
+          AgentUpdater._handleBirth(world, agent);
+        }
       } else {
+        // v4 fallback: countdown timer
         const birth = agent.pregnancy.tick(TICK_MS);
         if (birth) {
           AgentUpdater._handleBirth(world, agent);
@@ -1032,14 +1044,24 @@ export class AgentUpdater {
     }
 
     const [cx, cy] = free;
+    // For the v4.2 transfer mechanic, the child's initial fullness comes from
+    // the accumulated childNeeds.fullness; other needs are also transferred in.
+    const initialFullness = preg.useTransferMechanic
+      ? preg.childNeeds.fullness
+      : preg.donatedFullness;
     const child = AgentFactory.createChild(
       cx, cy,
       preg.childDna,
       preg.childFamilyName ?? agent.familyName,
       preg.childFactionId,
       agent.generation,
-      preg.donatedFullness
+      initialFullness
     );
+    if (preg.useTransferMechanic) {
+      child.needs.hygiene     = preg.childNeeds.hygiene;
+      child.needs.social      = preg.childNeeds.social;
+      child.needs.inspiration = preg.childNeeds.inspiration;
+    }
 
     // Set parent IDs for maternity feeding
     child.parentIds = [agent.id];


### PR DESCRIPTION
## Summary

- **`pregnancy.ts`**: Extended with v4.2 transfer mechanic fields (`useTransferMechanic`, `childNeeds`, `transferRate`, `gestationStartTick`). `start()` now takes an options object. New methods: `tickTransfer()` (drains parent needs, fills child needs per tick) and `isReadyForBirth()` (checks all child needs ≥ `TUNE.pregnancy.completionThreshold`). v4 `tick()` method preserved for fallback path.
- **`reproduce-effects.ts`**: Three pregnancy paths based on AG gene expression:
  1. **AG + gestationMs > 0** → gradual need-transfer gestation (v4.2 path)
  2. **AG + gestationMs = 0** → instant birth, all child needs at zero (child must be fed immediately)
  3. **No AG gene** → v4 countdown timer with fullness donation (backward compat)
  Mutation rate now driven by Volatility trait (average of both parents).
- **`agent-updater.ts`**: Pregnancy tick branches on `useTransferMechanic`. Transfer path calls `tickTransfer()` per tick and checks `isReadyForBirth()`. `_handleBirth` passes accumulated `childNeeds` to child for transfer births.
- **`persistence-manager.ts`**: `start()` migrated to options object; v4.2 fields restored from save data.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] Agents with AG gene in DNA begin gradual gestation pregnancies
- [ ] Parent's needs visibly drain during gestation
- [ ] Birth occurs when child needs reach threshold (not on a timer)
- [ ] Agents without AG gene use v4 fallback countdown timer
- [ ] Starvation + disease miscarriage conditions still work
- [ ] Save/load preserves pregnancy state for both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)