### PR TITLE
feat: v4.2 Phase 4 — modular rendering

### DIFF
--- a/src/domains/rendering/animation-runner.ts
+++ b/src/domains/rendering/animation-runner.ts
@@ -1,0 +1,125 @@
+import type { Agent } from '../entity/agent';
+import type { ActionType } from '../action/types';
+
+export type AnimationType =
+  | 'shake' | 'bob' | 'pulse' | 'bounce'
+  | 'shrink' | 'wiggle' | 'flash' | 'sway' | 'none';
+
+export interface AnimationState {
+  type: AnimationType;
+  startTime: number;
+  durationMs: number;
+}
+
+export interface AnimationTransform {
+  dx: number;
+  dy: number;
+  rotation: number;
+  scale: number;
+}
+
+/** Maps action types to their animation type. */
+export const ACTION_ANIMATIONS: Record<ActionType, AnimationType> = {
+  attack:     'shake',
+  quarrel:    'shake',
+  harvest:    'wiggle',
+  eat:        'wiggle',
+  reproduce:  'bounce',
+  seek_mate:  'bob',
+  await_mate: 'bob',
+  sleep:      'sway',
+  wash:       'wiggle',
+  talk:       'bob',
+  share:      'bob',
+  heal:       'pulse',
+  build_farm: 'wiggle',
+  deposit:    'wiggle',
+  withdraw:   'wiggle',
+  pickup:     'wiggle',
+  poop:       'wiggle',
+  clean:      'wiggle',
+  play:       'bounce',
+  idle:       'none',
+} as Record<ActionType, AnimationType>;
+
+/** Animation types triggered by simulation events (levelUp, death, birth, takeDamage). */
+export const EVENT_ANIMATIONS = {
+  takeDamage: 'shake'  as AnimationType,
+  death:      'shrink' as AnimationType,
+  levelUp:    'flash'  as AnimationType,
+  birth:      'bounce' as AnimationType,
+};
+
+const IDENTITY: AnimationTransform = { dx: 0, dy: 0, rotation: 0, scale: 1 };
+
+/**
+ * Tracks per-agent animation state.
+ * Action-based animations are derived from the agent's current action;
+ * event-triggered animations are stored per-agent and take priority.
+ */
+export class AnimationRunner {
+  /** Event-triggered animation states (take priority over action animations). */
+  private readonly _states = new Map<string, AnimationState>();
+
+  /** Trigger an event-driven animation on an agent (e.g. levelUp, takeDamage). */
+  trigger(agentId: string, type: AnimationType, durationMs = 500): void {
+    this._states.set(agentId, { type, startTime: performance.now(), durationMs });
+  }
+
+  /**
+   * Get the transform to apply when rendering this agent.
+   * Event-driven state takes priority; falls back to current action animation.
+   */
+  getTransform(agent: Agent): AnimationTransform {
+    const now = performance.now();
+    const stateAnim = this._states.get(agent.id);
+
+    // Clean up expired event animations
+    if (stateAnim && now - stateAnim.startTime >= stateAnim.durationMs) {
+      this._states.delete(agent.id);
+    }
+
+    const active = this._states.get(agent.id);
+    const actionAnimType: AnimationType = agent.action
+      ? (ACTION_ANIMATIONS[agent.action.type] ?? 'none')
+      : 'none';
+
+    const animType  = active?.type ?? actionAnimType;
+    const startTime = active?.startTime ?? (agent.action?.startedAtMs ?? now);
+    const duration  = active?.durationMs ?? 500;
+
+    return this._computeTransform(animType, startTime, duration, now);
+  }
+
+  private _computeTransform(
+    type: AnimationType,
+    startTime: number,
+    duration: number,
+    now: number
+  ): AnimationTransform {
+    const elapsed = now - startTime;
+    const t = Math.min(1, elapsed / duration);
+
+    switch (type) {
+      case 'shake':
+        return { dx: Math.sin(elapsed / 30) * 3 * (1 - t), dy: 0, rotation: 0, scale: 1 };
+      case 'bob':
+        return { dx: 0, dy: Math.sin(elapsed / 200) * 2, rotation: 0, scale: 1 };
+      case 'pulse':
+        return { dx: 0, dy: 0, rotation: 0, scale: 1 + Math.sin(elapsed / 200) * 0.1 };
+      case 'bounce':
+        return { dx: 0, dy: -Math.abs(Math.sin(elapsed / 150)) * 6 * (1 - t), rotation: 0, scale: 1 };
+      case 'shrink':
+        return { dx: 0, dy: 0, rotation: 0, scale: 1 - t };
+      case 'wiggle':
+        return { dx: 0, dy: 0, rotation: Math.sin(elapsed / 80) * 0.1, scale: 1 };
+      case 'flash':
+        return { dx: 0, dy: 0, rotation: 0, scale: 1 + Math.sin(elapsed / 100) * 0.2 };
+      case 'sway':
+        return { dx: Math.sin(elapsed / 1000) * 1, dy: 0, rotation: Math.sin(elapsed / 1000) * 0.05, scale: 1 };
+      case 'none':
+      default:
+        return IDENTITY;
+    }
+  }
+}

--- a/src/domains/rendering/indicator-renderer.ts
+++ b/src/domains/rendering/indicator-renderer.ts
@@ -1,0 +1,142 @@
+import { CELL_PX, WORLD_EMOJIS } from '../../core/constants';
+import type { Agent } from '../entity/agent';
+import type { World } from '../world/world';
+import { evaluateNeeds } from '../decision/need-evaluator';
+import { computeMood } from '../decision/mood-evaluator';
+import { Mood } from '../entity/types';
+import { EmojiCache } from './emoji-cache';
+
+export type IndicatorSource =
+  | 'faction_flag'
+  | 'pregnancy'
+  | 'health_band'
+  | 'mood'
+  | 'level'
+  | 'none';
+
+export interface IndicatorSlotConfig {
+  source: IndicatorSource;
+}
+
+const HEALTH_EMOJIS = {
+  good:   '\u{1F49A}',   // 💚
+  medium: '\u{1F49B}',   // 💛
+  low:    '\u2764\uFE0F', // ❤️
+} as const;
+
+const MOOD_EMOJIS: Record<string, string> = {
+  [Mood.HAPPY]:      '\u{1F600}',   // 😀
+  [Mood.CONTENT]:    '\u{1F642}',   // 🙂
+  [Mood.UNHAPPY]:    '\u{1F629}',   // 😩
+  [Mood.FRUSTRATED]: '\u{1F621}',   // 😡
+};
+
+/**
+ * Renders configurable indicator slots around an agent's cell.
+ * Three slots: topLeft, topRight, topMiddle.
+ *
+ * v4.2: Replaces the hardcoded pregnancy+faction_flag indicators in renderer.ts.
+ * Each slot can independently show faction_flag, pregnancy, health_band, mood,
+ * level, or nothing. The configuration can be changed at runtime via the UI.
+ */
+export class IndicatorRenderer {
+  private readonly _cache: EmojiCache;
+
+  constructor(
+    private readonly _slotConfig: {
+      topLeft:   IndicatorSlotConfig;
+      topRight:  IndicatorSlotConfig;
+      topMiddle: IndicatorSlotConfig;
+    },
+    emojiCache: EmojiCache
+  ) {
+    this._cache = emojiCache;
+  }
+
+  render(
+    ctx: CanvasRenderingContext2D,
+    agent: Agent,
+    cellPixelX: number,
+    cellPixelY: number,
+    world: World
+  ): void {
+    const indicatorSize = CELL_PX * 0.45;
+
+    const positions = {
+      topLeft:   { x: cellPixelX + CELL_PX * 0.05,  y: cellPixelY - CELL_PX * 0.35 },
+      topRight:  { x: cellPixelX + CELL_PX * 0.7,   y: cellPixelY - CELL_PX * 0.35 },
+      topMiddle: { x: cellPixelX + CELL_PX * 0.375, y: cellPixelY - CELL_PX * 0.5  },
+    };
+
+    this._renderSlot(ctx, agent, this._slotConfig.topLeft,   positions.topLeft,   indicatorSize, world);
+    this._renderSlot(ctx, agent, this._slotConfig.topRight,  positions.topRight,  indicatorSize, world);
+    this._renderSlot(ctx, agent, this._slotConfig.topMiddle, positions.topMiddle, indicatorSize, world);
+  }
+
+  private _renderSlot(
+    ctx: CanvasRenderingContext2D,
+    agent: Agent,
+    slot: IndicatorSlotConfig,
+    pos: { x: number; y: number },
+    size: number,
+    world: World
+  ): void {
+    if (slot.source === 'faction_flag') {
+      if (!agent.factionId) return;
+      const faction = world.factions.get(agent.factionId);
+      if (!faction) return;
+      const { canvas: fc, w, h } = this._cache.getTinted(WORLD_EMOJIS.flag, faction.color);
+      const scale = Math.min(size / w, size / h);
+      ctx.drawImage(fc, pos.x, pos.y, w * scale, h * scale);
+      return;
+    }
+
+    if (slot.source === 'level') {
+      ctx.save();
+      ctx.font = `bold ${Math.round(size * 0.7)}px sans-serif`;
+      ctx.fillStyle = '#ffffcc';
+      ctx.strokeStyle = '#333';
+      ctx.lineWidth = 2;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.strokeText(String(agent.level), pos.x + size / 2, pos.y + size / 2);
+      ctx.fillText(String(agent.level), pos.x + size / 2, pos.y + size / 2);
+      ctx.restore();
+      return;
+    }
+
+    const emoji = this._resolveEmoji(agent, slot.source, world);
+    if (!emoji) return;
+
+    const { canvas: ec, w, h } = this._cache.get(emoji);
+    const scale = Math.min(size / w, size / h);
+    ctx.drawImage(ec, pos.x, pos.y, w * scale, h * scale);
+  }
+
+  private _resolveEmoji(agent: Agent, source: IndicatorSource, _world: World): string | null {
+    switch (source) {
+      case 'faction_flag':
+        return null; // handled in _renderSlot via tinted flag
+      case 'pregnancy':
+        return agent.pregnancy.active ? '\u{1F95A}' : null;   // 🥚
+      case 'health_band': {
+        const ratio = agent.maxHealth > 0 ? agent.health / agent.maxHealth : 0;
+        if (ratio > 0.7) return HEALTH_EMOJIS.good;
+        if (ratio > 0.3) return HEALTH_EMOJIS.medium;
+        return HEALTH_EMOJIS.low;
+      }
+      case 'mood': {
+        const mood = computeMood(evaluateNeeds(agent));
+        return MOOD_EMOJIS[mood] ?? null;
+      }
+      case 'none':
+      default:
+        return null;
+    }
+  }
+
+  /** Update a slot's source (called from the indicator config UI). */
+  setSlot(slot: 'topLeft' | 'topRight' | 'topMiddle', source: IndicatorSource): void {
+    this._slotConfig[slot].source = source;
+  }
+}

--- a/src/domains/rendering/renderer.ts
+++ b/src/domains/rendering/renderer.ts
@@ -4,10 +4,14 @@ import type { TerrainField } from '../world/terrain-field';
 import type { World } from '../world';
 import type { DeathCause } from '../world/types';
 import type { Agent } from '../entity/agent';
+import type { IActionState } from '../action/types';
 import { evaluateNeeds } from '../decision/need-evaluator';
 import { computeMood } from '../decision/mood-evaluator';
 import { Camera } from './camera';
 import { EmojiCache } from './emoji-cache';
+import { AnimationRunner } from './animation-runner';
+import { IndicatorRenderer } from './indicator-renderer';
+import { ToolRenderer } from './tool-renderer';
 
 // Inline constants that were in TUNE
 const POOP_DECAY_MS = 30000;
@@ -47,6 +51,17 @@ const LOD_OBSTACLE = '#888888';
 
 export class Renderer {
   private readonly _emojiCache = new EmojiCache();
+  private readonly _animationRunner = new AnimationRunner();
+  private readonly _indicatorRenderer: IndicatorRenderer;
+  private readonly _toolRenderer: ToolRenderer;
+
+  constructor() {
+    this._indicatorRenderer = new IndicatorRenderer(
+      { topLeft: { source: 'faction_flag' }, topRight: { source: 'pregnancy' }, topMiddle: { source: 'health_band' } },
+      this._emojiCache
+    );
+    this._toolRenderer = new ToolRenderer(this._emojiCache);
+  }
 
   // --- Terrain cache ---
   private _terrainCanvas: HTMLCanvasElement | null = null;
@@ -105,12 +120,10 @@ export class Renderer {
     this._drawObstacles(ctx, world, vb, lod);
     this._drawFlags(ctx, world, vb, lod);
 
-    const pendingAttackLines: [Agent, Agent][] = [];
-    const pendingHarvestLines: [Agent, { x: number; y: number }][] = [];
-    this._drawAgents(ctx, world, pendingAttackLines, pendingHarvestLines, vb);
+    const pendingToolLines: Array<{ agent: Agent; action: IActionState }> = [];
+    this._drawAgents(ctx, world, pendingToolLines, vb);
     this._drawDeadMarkers(ctx, world, vb, lod);
-    this._drawAttackLines(ctx, camera, pendingAttackLines);
-    this._drawHarvestLines(ctx, pendingHarvestLines);
+    this._toolRenderer.renderAll(ctx, pendingToolLines, world);
     this._drawSelectedAgentPath(ctx, world);
 
     this._drawClouds(ctx, world, camera, vb, lod);
@@ -479,7 +492,7 @@ export class Renderer {
     return `hsl(${hue}, 85%, 50%)`;
   }
 
-  private _drawAgents(ctx: CanvasRenderingContext2D, world: World, attackLines: [Agent, Agent][], harvestLines: [Agent, { x: number; y: number }][], vb: ViewBounds): void {
+  private _drawAgents(ctx: CanvasRenderingContext2D, world: World, toolLines: Array<{ agent: Agent; action: IActionState }>, vb: ViewBounds): void {
     const now = performance.now();
     for (const agent of world.agents) {
       if (!this._inView(agent.cellX, agent.cellY, vb) &&
@@ -510,75 +523,27 @@ export class Renderer {
         emoji = getIdleEmoji(agent, mood);
       }
 
-      let offX = 0, offY = 0, angle = 0, sx = 1, sy = 1;
-
-      if (actionType === 'attack') {
-        offX = Math.sin(now * 0.038) * 2.5;
-      } else if (actionType === 'harvest') {
-        offY = -Math.abs(Math.sin(now * 0.007)) * 3;
-      } else if (actionType === 'poop') {
-        const elapsed = now - (agent.action!.startedAtMs ?? now);
-        const progress = Math.min(1, elapsed / (agent.action!.totalMs || 1500));
-        if (progress < 0.7) {
-          const eased = Math.sin((progress / 0.7) * Math.PI / 2);
-          sy = 1 - 0.38 * eased;
-        } else {
-          const eased = Math.sin(((progress - 0.7) / 0.3) * Math.PI / 2);
-          sy = 0.62 + 0.38 * eased;
-        }
-        offY = (1 - sy) * (CELL_PX / 2);
-      } else if (actionType === 'share') {
-        offX = Math.sin(now * 0.005) * 2;
-      }
-
+      const transform = this._animationRunner.getTransform(agent);
+      let rotation = transform.rotation;
       const isMoving = t < 1 && (agent.prevCellX !== agent.cellX || agent.prevCellY !== agent.cellY);
       if (isMoving) {
         const ddx = agent.cellX - (agent.prevCellX ?? agent.cellX);
         const ddy = agent.cellY - (agent.prevCellY ?? agent.cellY);
         const tilt = 0.25;
-        angle = Math.atan2(ddy, ddx) + Math.PI / 2 + Math.sin(now * 0.015) * tilt;
+        rotation = Math.atan2(ddy, ddx) + Math.PI / 2 + Math.sin(now * 0.015) * tilt;
       }
 
       ctx.save();
-      ctx.translate(cx + offX, cy + offY);
-      if (angle !== 0) ctx.rotate(angle);
-      if (sx !== 1 || sy !== 1) ctx.scale(sx, sy);
+      ctx.translate(cx + transform.dx, cy + transform.dy);
+      if (rotation !== 0) ctx.rotate(rotation);
+      if (transform.scale !== 1) ctx.scale(transform.scale, transform.scale);
       ctx.translate(-cx, -cy);
       this._drawAgentEmoji(ctx, x, y, CELL_PX / 2 - 3, ringColor, emoji);
       ctx.restore();
 
-      // Pregnancy visual: egg above head
-      if (agent.pregnancy.active) {
-        const { canvas: eggC, w: ew, h: eh } = this._emojiCache.get('\u{1F95A}'); // 🥚
-        const eggSize = CELL_PX / 2.5;
-        const eScale = Math.min(eggSize / ew, eggSize / eh);
-        const edw = ew * eScale;
-        const edh = eh * eScale;
-        // Bob gently up and down
-        const bob = Math.sin(performance.now() * 0.004) * 1.5;
-        ctx.drawImage(eggC, x + (CELL_PX - edw) / 2, y - edh + bob, edw, edh);
-      }
+      this._indicatorRenderer.render(ctx, agent, x, y, world);
 
-      if (agent.factionId) {
-        const faction = world.factions.get(agent.factionId);
-        if (faction) {
-          const { canvas: fc, w: fw, h: fh } = this._emojiCache.getTinted(WORLD_EMOJIS.flag, faction.color);
-          const flagSize = CELL_PX / 3;
-          const fScale = Math.min(flagSize / fw, flagSize / fh);
-          const fdw = fw * fScale;
-          const fdh = fh * fScale;
-          ctx.drawImage(fc, x + CELL_PX - fdw, y, fdw, fdh);
-        }
-      }
-
-      if (agent.action?.type === 'attack' && agent.action.payload?.targetId) {
-        const t2 = world.agentsById.get(agent.action.payload.targetId);
-        if (t2) attackLines.push([agent, t2]);
-      }
-
-      if (agent.action?.type === 'harvest' && agent.action.payload?.targetPos) {
-        harvestLines.push([agent, agent.action.payload.targetPos]);
-      }
+      if (agent.action) toolLines.push({ agent, action: agent.action });
 
       if (world.selectedId === agent.id) this._drawStar(ctx, x + CELL_PX / 2, y - 16);
     }
@@ -659,68 +624,6 @@ export class Renderer {
       }
 
       ctx.globalAlpha = 1;
-    }
-  }
-
-  // --- Attack lines ---
-
-  private _drawAttackLines(ctx: CanvasRenderingContext2D, _camera: Camera, lines: [Agent, Agent][]): void {
-    const daggerEmoji = '\uD83D\uDDE1\uFE0F'; // 🗡️
-    const { canvas: ec, w, h } = this._emojiCache.get(daggerEmoji);
-    const daggerSize = CELL_PX - 2;
-    const scale = Math.min(daggerSize / w, daggerSize / h);
-    const dw = w * scale;
-    const dh = h * scale;
-
-    for (const [att, tgt] of lines) {
-      const at = att.lerpT != null ? att.lerpT : 1;
-      const ax = ((att.prevCellX ?? att.cellX) + (att.cellX - (att.prevCellX ?? att.cellX)) * at) * CELL_PX + CELL_PX / 2;
-      const ay = ((att.prevCellY ?? att.cellY) + (att.cellY - (att.prevCellY ?? att.cellY)) * at) * CELL_PX + CELL_PX / 2;
-      const tt = tgt.lerpT != null ? tgt.lerpT : 1;
-      const tx = ((tgt.prevCellX ?? tgt.cellX) + (tgt.cellX - (tgt.prevCellX ?? tgt.cellX)) * tt) * CELL_PX + CELL_PX / 2;
-      const ty = ((tgt.prevCellY ?? tgt.cellY) + (tgt.cellY - (tgt.prevCellY ?? tgt.cellY)) * tt) * CELL_PX + CELL_PX / 2;
-
-      const mx = (ax + tx) / 2;
-      const my = (ay + ty) / 2;
-      const angle = Math.atan2(ty - ay, tx - ax) + Math.PI * 1.25;
-
-      ctx.save();
-      ctx.globalAlpha = 0.9;
-      ctx.translate(mx, my);
-      ctx.rotate(angle);
-      ctx.drawImage(ec, -dw / 2, -dh / 2, dw, dh);
-      ctx.restore();
-    }
-  }
-
-  // --- Harvest lines ---
-
-  private _drawHarvestLines(ctx: CanvasRenderingContext2D, lines: [Agent, { x: number; y: number }][]): void {
-    if (lines.length === 0) return;
-    const handEmoji = '\u{1F91A}'; // 🤚
-    const { canvas: ec, w, h } = this._emojiCache.get(handEmoji);
-    const handSize = CELL_PX - 4;
-    const scale = Math.min(handSize / w, handSize / h);
-    const dw = w * scale;
-    const dh = h * scale;
-
-    for (const [agent, targetPos] of lines) {
-      const at = agent.lerpT != null ? agent.lerpT : 1;
-      const ax = ((agent.prevCellX ?? agent.cellX) + (agent.cellX - (agent.prevCellX ?? agent.cellX)) * at) * CELL_PX + CELL_PX / 2;
-      const ay = ((agent.prevCellY ?? agent.cellY) + (agent.cellY - (agent.prevCellY ?? agent.cellY)) * at) * CELL_PX + CELL_PX / 2;
-      const tx = targetPos.x * CELL_PX + CELL_PX / 2;
-      const ty = targetPos.y * CELL_PX + CELL_PX / 2;
-
-      const mx = (ax + tx) / 2;
-      const my = (ay + ty) / 2;
-      const angle = Math.atan2(ty - ay, tx - ax) + Math.PI / 2;
-
-      ctx.save();
-      ctx.globalAlpha = 0.85;
-      ctx.translate(mx, my);
-      ctx.rotate(angle);
-      ctx.drawImage(ec, -dw / 2, -dh / 2, dw, dh);
-      ctx.restore();
     }
   }
 

--- a/src/domains/rendering/tool-renderer.ts
+++ b/src/domains/rendering/tool-renderer.ts
@@ -1,0 +1,95 @@
+import { CELL_PX } from '../../core/constants';
+import type { Agent } from '../entity/agent';
+import type { World } from '../world/world';
+import type { IActionState } from '../action/types';
+import { ACTION_REGISTRY } from '../action/action-registry';
+import { EmojiCache } from './emoji-cache';
+
+/**
+ * Renders tool emojis between an agent and its action target.
+ *
+ * v4.2: Generalises the hardcoded attack (🗡️) and harvest (🤚) line rendering
+ * in renderer.ts to any action with `targetType === 'external_cell'` and a
+ * non-null `tool` in the action registry.
+ *
+ * Tool emojis are drawn at the midpoint between agent and target, rotated to
+ * face the target.
+ */
+export class ToolRenderer {
+  private readonly _cache: EmojiCache;
+
+  constructor(emojiCache: EmojiCache) {
+    this._cache = emojiCache;
+  }
+
+  /**
+   * Render tool lines for all agents collected during the agent-render pass.
+   * Called after the agent pass so tools appear on top of agents.
+   */
+  renderAll(
+    ctx: CanvasRenderingContext2D,
+    lines: Array<{ agent: Agent; action: IActionState }>,
+    world: World
+  ): void {
+    for (const { agent, action } of lines) {
+      this._renderTool(ctx, agent, action, world);
+    }
+  }
+
+  private _renderTool(
+    ctx: CanvasRenderingContext2D,
+    agent: Agent,
+    action: IActionState,
+    world: World
+  ): void {
+    const def = ACTION_REGISTRY.get(action.type);
+    if (!def || def.targetType !== 'external_cell' || !def.tool) return;
+
+    const targetPx = this._resolveTargetPx(action, world);
+    if (!targetPx) return;
+
+    const at = agent.lerpT != null ? agent.lerpT : 1;
+    const ax = ((agent.prevCellX ?? agent.cellX) + (agent.cellX - (agent.prevCellX ?? agent.cellX)) * at) * CELL_PX + CELL_PX / 2;
+    const ay = ((agent.prevCellY ?? agent.cellY) + (agent.cellY - (agent.prevCellY ?? agent.cellY)) * at) * CELL_PX + CELL_PX / 2;
+
+    const mx = (ax + targetPx.x) / 2;
+    const my = (ay + targetPx.y) / 2;
+    const angle = Math.atan2(targetPx.y - ay, targetPx.x - ax);
+
+    const { canvas: ec, w, h } = this._cache.get(def.tool);
+    const toolSize = CELL_PX - 2;
+    const scale = Math.min(toolSize / w, toolSize / h);
+    const dw = w * scale;
+    const dh = h * scale;
+
+    ctx.save();
+    ctx.globalAlpha = 0.9;
+    ctx.translate(mx, my);
+    // Offset angle by 5π/4 to match existing attack-line orientation convention
+    ctx.rotate(angle + Math.PI * 1.25);
+    ctx.drawImage(ec, -dw / 2, -dh / 2, dw, dh);
+    ctx.restore();
+  }
+
+  private _resolveTargetPx(
+    action: IActionState,
+    world: World
+  ): { x: number; y: number } | null {
+    if (action.payload?.targetId) {
+      const target = world.agentsById.get(action.payload.targetId);
+      if (!target) return null;
+      const tt = target.lerpT != null ? target.lerpT : 1;
+      return {
+        x: ((target.prevCellX ?? target.cellX) + (target.cellX - (target.prevCellX ?? target.cellX)) * tt) * CELL_PX + CELL_PX / 2,
+        y: ((target.prevCellY ?? target.cellY) + (target.cellY - (target.prevCellY ?? target.cellY)) * tt) * CELL_PX + CELL_PX / 2,
+      };
+    }
+    if (action.payload?.targetPos) {
+      return {
+        x: action.payload.targetPos.x * CELL_PX + CELL_PX / 2,
+        y: action.payload.targetPos.y * CELL_PX + CELL_PX / 2,
+      };
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- **AnimationRunner** (`animation-runner.ts`): maps all 20 action types to animation transforms (shake, bob, pulse, bounce, shrink, wiggle, flash, sway, none); event-driven animations (takeDamage, death, levelUp, birth) take priority over action animations
- **IndicatorRenderer** (`indicator-renderer.ts`): replaces hardcoded pregnancy-egg and faction-flag overlays with a configurable 3-slot system (topLeft=faction_flag, topRight=pregnancy, topMiddle=health_band by default); supports faction_flag, pregnancy, health_band, mood, level, none
- **ToolRenderer** (`tool-renderer.ts`): generalises `_drawAttackLines` / `_drawHarvestLines` to any action with `targetType='external_cell'` and a non-null `tool` in the action registry
- **renderer.ts**: wires all three modules in; removes inline animation switch, pregnancy/faction indicator blocks, `_drawAttackLines`, `_drawHarvestLines`

## Test plan

- [ ] Agents shake during attack, wiggle during harvest/eat/wash
- [ ] Agent bounces at birth (event animation), shrinks on death
- [ ] Faction flag tinted indicator appears top-left; pregnancy egg appears top-right; health heart appears top-middle
- [ ] Dagger (🗡️) appears between attacker and target; hand (🤚) appears between harvester and tree
- [ ] No TypeScript errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)