### PR TITLE
feat: v4.2 Phase 5 — WorldGenerator and indicator config UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1053,6 +1053,7 @@
             <label class="toggle-row"><input type="checkbox" id="cbPauseOnBlur"/> Pause when unfocused</label>
             <label class="toggle-row"><input type="checkbox" id="cbDrawGrid"/> Draw grid overlays</label>
           </div>
+          <div id="indicatorConfigMount" style="margin-top:14px"></div>
         </div>
       </div>
     </div>

--- a/src/domains/rendering/renderer.ts
+++ b/src/domains/rendering/renderer.ts
@@ -63,6 +63,9 @@ export class Renderer {
     this._toolRenderer = new ToolRenderer(this._emojiCache);
   }
 
+  get indicatorRenderer(): IndicatorRenderer { return this._indicatorRenderer; }
+  get animationRunner(): AnimationRunner { return this._animationRunner; }
+
   // --- Terrain cache ---
   private _terrainCanvas: HTMLCanvasElement | null = null;
   private _terrainCtx: CanvasRenderingContext2D | null = null;

--- a/src/domains/ui/controls.ts
+++ b/src/domains/ui/controls.ts
@@ -1,61 +1,15 @@
 import { key, rndi, uuid, RingLog } from '../../core/utils';
-import { GRID_SIZE, LOG_CATS, OBSTACLE_EMOJIS, setGridSize } from '../../core/constants';
+import { GRID_SIZE, LOG_CATS, setGridSize } from '../../core/constants';
 import type { World } from '../world';
 import { AgentFactory } from '../entity/agent-factory';
 import { SimulationEngine } from '../simulation';
 import { PersistenceManager } from '../persistence';
 import type { DomRefs } from './ui-manager';
 import { UIManager } from './ui-manager';
+import { WorldGenerator } from '../world/world-generator';
 
-// Inlined TUNE constants
-const SALT_WATER_SPAWN_RANGE: [number, number] = [1, 3];
 const CLOUD_LIFETIME_RANGE: [number, number] = [5000, 10000];
-
-function seedEnvironment(world: World): void {
-  for (let i = 0; i < 4; i++) {
-    const x = rndi(5, GRID_SIZE -6);
-    const y = rndi(5, GRID_SIZE -6);
-    world.farms.set(key(x, y), { id: uuid(), x, y, spawnsRemaining: 12, spawnTimerMs: rndi(15000, 25000) });
-  }
-  // Scatter random obstacles — mix of 1x1 and 2x2
-  const obstacleCount = rndi(30, 50);
-  for (let i = 0; i < obstacleCount; i++) {
-    const emoji = OBSTACLE_EMOJIS[Math.floor(Math.random() * OBSTACLE_EMOJIS.length)];
-    if (Math.random() < 0.4) {
-      // Try 2x2 placement — one shared obstacle object across all 4 cells
-      let placed = false;
-      for (let attempt = 0; attempt < 50; attempt++) {
-        const x = rndi(1, GRID_SIZE -3);
-        const y = rndi(1, GRID_SIZE -3);
-        if (!world.grid.isCellOccupied(x, y) &&
-            !world.grid.isCellOccupied(x + 1, y) &&
-            !world.grid.isCellOccupied(x, y + 1) &&
-            !world.grid.isCellOccupied(x + 1, y + 1)) {
-          const obs = { id: uuid(), x, y, emoji, hp: 24, maxHp: 24, size: '2x2' as const };
-          world.obstacles.set(key(x, y),         obs);
-          world.obstacles.set(key(x + 1, y),     obs);
-          world.obstacles.set(key(x, y + 1),     obs);
-          world.obstacles.set(key(x + 1, y + 1), obs);
-          placed = true;
-          break;
-        }
-      }
-      if (!placed) {
-        const { x, y } = world.grid.randomFreeCell();
-        world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji, hp: 12, maxHp: 12 });
-      }
-    } else {
-      const { x, y } = world.grid.randomFreeCell();
-      world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji, hp: 12, maxHp: 12 });
-    }
-  }
-  SimulationEngine.seedInitialSaltWater(world, rndi(SALT_WATER_SPAWN_RANGE[0], SALT_WATER_SPAWN_RANGE[1]));
-  SimulationEngine.seedInitialTrees(world, rndi(8, 15));
-  SimulationEngine.seedInitialWater(world, rndi(3, 6));
-  SimulationEngine.seedInitialFood(world, rndi(5, 10));
-  world.terrainField.recomputeAll(world.grid);
-  world.terrainField.snapDisplay();
-}
+const _worldGenerator = new WorldGenerator();
 
 export class Controls {
   static wire(world: World, dom: DomRefs, doRenderLog: () => void, onWorldResize?: () => void): void {
@@ -142,7 +96,7 @@ export class Controls {
 
       world.speedPct = Number(ranges.rngSpeed?.value || 100);
       world.cloudSpawnRate = Number(ranges.rngCloudRate?.value || 1);
-      seedEnvironment(world);
+      _worldGenerator.seed(world);
       spawnAgents(Number(ranges.rngAgents?.value || 20));
       world.running = true;
       if (buttons.btnStart) buttons.btnStart.style.display = 'none';

--- a/src/domains/ui/indicator-config.ts
+++ b/src/domains/ui/indicator-config.ts
@@ -1,0 +1,61 @@
+import type { IndicatorRenderer, IndicatorSource } from '../rendering/indicator-renderer';
+
+const SLOT_LABELS: Record<'topLeft' | 'topRight' | 'topMiddle', string> = {
+  topLeft:   'Top-Left',
+  topRight:  'Top-Right',
+  topMiddle: 'Top-Middle',
+};
+
+const SOURCE_OPTIONS: Array<{ value: IndicatorSource; label: string }> = [
+  { value: 'faction_flag', label: 'Faction Flag' },
+  { value: 'pregnancy',    label: 'Pregnancy'    },
+  { value: 'health_band',  label: 'Health'       },
+  { value: 'mood',         label: 'Mood'         },
+  { value: 'level',        label: 'Level'        },
+  { value: 'none',         label: 'None'         },
+];
+
+/**
+ * Renders a small configuration UI for the three indicator slots.
+ * Call `mount(container)` to inject it into the DOM.
+ *
+ * v4.2: Allows users to choose what each indicator slot above agents displays.
+ */
+export class IndicatorConfigPanel {
+  constructor(private readonly _indicatorRenderer: IndicatorRenderer) {}
+
+  mount(container: HTMLElement): void {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'indicator-config';
+
+    const heading = document.createElement('div');
+    heading.className = 'indicator-config-heading';
+    heading.textContent = 'Agent Indicators';
+    wrapper.appendChild(heading);
+
+    for (const slot of ['topLeft', 'topRight', 'topMiddle'] as const) {
+      const row = document.createElement('label');
+      row.className = 'indicator-config-row';
+
+      const labelSpan = document.createElement('span');
+      labelSpan.textContent = SLOT_LABELS[slot];
+      row.appendChild(labelSpan);
+
+      const select = document.createElement('select');
+      select.className = 'indicator-config-select';
+      for (const opt of SOURCE_OPTIONS) {
+        const option = document.createElement('option');
+        option.value = opt.value;
+        option.textContent = opt.label;
+        select.appendChild(option);
+      }
+      select.addEventListener('change', () => {
+        this._indicatorRenderer.setSlot(slot, select.value as IndicatorSource);
+      });
+      row.appendChild(select);
+      wrapper.appendChild(row);
+    }
+
+    container.appendChild(wrapper);
+  }
+}

--- a/src/domains/world/world-generator.ts
+++ b/src/domains/world/world-generator.ts
@@ -1,0 +1,124 @@
+import { GRID_SIZE, OBSTACLE_EMOJIS } from '../../core/constants';
+import { key, rndi, uuid } from '../../core/utils';
+import { TUNE } from '../../core/tuning';
+import type { World } from './world';
+import { SimulationEngine } from '../simulation';
+
+const SALT_WATER_SPAWN_RANGE: [number, number] = [1, 3];
+
+/**
+ * Extracts and expands v4's world setup logic (previously `seedEnvironment` in
+ * `controls.ts`) into a dedicated module.
+ *
+ * v4.2: Adds Voronoi-style isolation barriers that divide the map into
+ * semi-separated population pockets.
+ */
+export class WorldGenerator {
+  /**
+   * Seed a freshly cleared World with terrain, water, trees, food, obstacles,
+   * farms, and isolation barriers.
+   */
+  seed(world: World): void {
+    this._placeFarms(world);
+    this._placeRandomObstacles(world);
+    this._createIsolationBarriers(world, TUNE.world.isolationPocketCount);
+    SimulationEngine.seedInitialSaltWater(world, rndi(SALT_WATER_SPAWN_RANGE[0], SALT_WATER_SPAWN_RANGE[1]));
+    SimulationEngine.seedInitialTrees(world, rndi(8, 15));
+    SimulationEngine.seedInitialWater(world, rndi(3, 6));
+    SimulationEngine.seedInitialFood(world, rndi(5, 10));
+    world.terrainField.recomputeAll(world.grid);
+    world.terrainField.snapDisplay();
+  }
+
+  private _placeFarms(world: World): void {
+    for (let i = 0; i < 4; i++) {
+      const x = rndi(5, GRID_SIZE - 6);
+      const y = rndi(5, GRID_SIZE - 6);
+      world.farms.set(key(x, y), { id: uuid(), x, y, spawnsRemaining: 12, spawnTimerMs: rndi(15000, 25000) });
+    }
+  }
+
+  private _placeRandomObstacles(world: World): void {
+    const obstacleCount = rndi(30, 50);
+    for (let i = 0; i < obstacleCount; i++) {
+      const emoji = OBSTACLE_EMOJIS[Math.floor(Math.random() * OBSTACLE_EMOJIS.length)];
+      if (Math.random() < 0.4) {
+        let placed = false;
+        for (let attempt = 0; attempt < 50; attempt++) {
+          const x = rndi(1, GRID_SIZE - 3);
+          const y = rndi(1, GRID_SIZE - 3);
+          if (!world.grid.isCellOccupied(x, y) &&
+              !world.grid.isCellOccupied(x + 1, y) &&
+              !world.grid.isCellOccupied(x, y + 1) &&
+              !world.grid.isCellOccupied(x + 1, y + 1)) {
+            const obs = { id: uuid(), x, y, emoji, hp: 24, maxHp: 24, size: '2x2' as const };
+            world.obstacles.set(key(x, y),         obs);
+            world.obstacles.set(key(x + 1, y),     obs);
+            world.obstacles.set(key(x, y + 1),     obs);
+            world.obstacles.set(key(x + 1, y + 1), obs);
+            placed = true;
+            break;
+          }
+        }
+        if (!placed) {
+          const { x, y } = world.grid.randomFreeCell();
+          world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji, hp: 12, maxHp: 12 });
+        }
+      } else {
+        const { x, y } = world.grid.randomFreeCell();
+        world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji, hp: 12, maxHp: 12 });
+      }
+    }
+  }
+
+  /**
+   * Voronoi-style isolation: pick `pocketCount` random seed cells, assign
+   * every cell to its nearest seed, then place obstacles along the boundaries
+   * between regions. Boundary cells are placed with ~40% probability to leave
+   * occasional gaps for cross-region travel.
+   */
+  private _createIsolationBarriers(world: World, pocketCount: number): void {
+    if (pocketCount < 2) return;
+
+    // Pick random region seeds (avoid edges)
+    const margin = 8;
+    const seeds: Array<{ x: number; y: number }> = [];
+    for (let i = 0; i < pocketCount; i++) {
+      seeds.push({ x: rndi(margin, GRID_SIZE - margin), y: rndi(margin, GRID_SIZE - margin) });
+    }
+
+    // Assign each cell to its nearest seed
+    const region = new Int8Array(GRID_SIZE * GRID_SIZE);
+    for (let y = 0; y < GRID_SIZE; y++) {
+      for (let x = 0; x < GRID_SIZE; x++) {
+        let minDist = Infinity;
+        let nearest = 0;
+        for (let s = 0; s < seeds.length; s++) {
+          const dx = x - seeds[s].x;
+          const dy = y - seeds[s].y;
+          const d = dx * dx + dy * dy;
+          if (d < minDist) { minDist = d; nearest = s; }
+        }
+        region[y * GRID_SIZE + x] = nearest;
+      }
+    }
+
+    // Place obstacles on boundary cells (cells adjacent to a different region)
+    const emoji = OBSTACLE_EMOJIS[Math.floor(Math.random() * OBSTACLE_EMOJIS.length)];
+    for (let y = 1; y < GRID_SIZE - 1; y++) {
+      for (let x = 1; x < GRID_SIZE - 1; x++) {
+        const r = region[y * GRID_SIZE + x];
+        const isBoundary =
+          region[y * GRID_SIZE + (x - 1)] !== r ||
+          region[y * GRID_SIZE + (x + 1)] !== r ||
+          region[(y - 1) * GRID_SIZE + x] !== r ||
+          region[(y + 1) * GRID_SIZE + x] !== r;
+        if (!isBoundary) continue;
+        // ~40% fill — leave gaps for cross-region pathfinding
+        if (Math.random() > 0.4) continue;
+        if (world.grid.isCellOccupied(x, y)) continue;
+        world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji, hp: 12, maxHp: 12 });
+      }
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,13 @@
 import { TICK_MS, CELL_PX } from './core/constants';
 
-const VERSION = '4.1.4';
+const VERSION = '4.2.0';
 import { World } from './domains/world';
 import { Camera } from './domains/rendering/camera';
 import { Renderer } from './domains/rendering/renderer';
 import { UIManager } from './domains/ui/ui-manager';
 import { InputHandler } from './domains/ui/input-handler';
 import { Controls } from './domains/ui/controls';
+import { IndicatorConfigPanel } from './domains/ui/indicator-config';
 import { SimulationEngine } from './domains/simulation';
 import { PersistenceManager } from './domains/persistence';
 
@@ -61,6 +62,12 @@ document.addEventListener('DOMContentLoaded', () => {
   // Wire input + controls
   InputHandler.setup(canvas, camera, world, dom);
   Controls.wire(world, dom, doRenderLog, refreshCanvasSize);
+
+  // Indicator config panel
+  const indicatorMount = document.querySelector<HTMLElement>('#indicatorConfigMount');
+  if (indicatorMount) {
+    new IndicatorConfigPanel(renderer.indicatorRenderer).mount(indicatorMount);
+  }
 
   // Restore autosave if available
   const autosaveData = PersistenceManager.loadAutosave();


### PR DESCRIPTION
## Summary

- **WorldGenerator** (`world/world-generator.ts`): extracts and expands the old `seedEnvironment()` function from `controls.ts`; adds Voronoi-style isolation barriers — picks `TUNE.world.isolationPocketCount` random seeds, assigns each cell to its nearest seed, then places obstacles along region boundaries with ~40% probability to leave pathfinding gaps
- **IndicatorConfigPanel** (`ui/indicator-config.ts`): three dropdowns in the Interaction Tools panel (Top-Left, Top-Right, Top-Middle) that call `indicatorRenderer.setSlot()` on change
- **controls.ts**: `seedEnvironment()` replaced by `_worldGenerator.seed(world)`
- **renderer.ts**: exposes `indicatorRenderer` and `animationRunner` getters for external access
- **main.ts**: mounts `IndicatorConfigPanel` into `#indicatorConfigMount` after setup; bumps version to 4.2.0
- **index.html**: adds `<div id="indicatorConfigMount">` in the Tools panel body

## Test plan

- [ ] Starting a new simulation produces isolated population pockets visible as obstacle bands
- [ ] Interaction Tools panel shows "Agent Indicators" section with three dropdowns
- [ ] Changing a dropdown slot updates which indicator renders above agents in real time
- [ ] No TypeScript errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)