### PR TITLE
feat: v4.2 Phase 6 — persistence schema update and backward-compat loading

### DIFF
--- a/src/domains/persistence/persistence-manager.ts
+++ b/src/domains/persistence/persistence-manager.ts
@@ -7,7 +7,7 @@ import { Agent } from '../entity/agent';
 import { Genome } from '../genetics';
 import { Faction, FactionManager } from '../faction';
 
-const VERSION = '4.1.4';
+const VERSION = '4.2.0';
 
 // Inlined TUNE constants
 const FARM_MAX_SPAWNS = 12;
@@ -131,15 +131,21 @@ export class PersistenceManager {
         ['wood', a.resourceMemory.get('wood') ?? []],
       ],
       pregnancy: a.pregnancy.active ? {
-        remainingMs: a.pregnancy.remainingMs,
-        childDna: a.pregnancy.childDna,
-        childFamilyName: a.pregnancy.childFamilyName,
-        childFactionId: a.pregnancy.childFactionId,
-        partnerId: a.pregnancy.partnerId,
-        donatedFullness: a.pregnancy.donatedFullness,
+        remainingMs:         a.pregnancy.remainingMs,
+        childDna:            a.pregnancy.childDna,
+        childFamilyName:     a.pregnancy.childFamilyName,
+        childFactionId:      a.pregnancy.childFactionId,
+        partnerId:           a.pregnancy.partnerId,
+        donatedFullness:     a.pregnancy.donatedFullness,
+        // v4.2 transfer mechanic fields
+        useTransferMechanic: a.pregnancy.useTransferMechanic,
+        childNeeds:          a.pregnancy.useTransferMechanic ? { ...a.pregnancy.childNeeds } : null,
+        transferRate:        a.pregnancy.transferRate,
+        gestationStartTick:  a.pregnancy.gestationStartTick,
       } : null,
     }));
     return {
+      version: 'v4.2',
       meta: { version: VERSION, savedAt: Date.now() },
       grid: { CELL: CELL_PX, GRID: GRID_SIZE },
       state: {
@@ -230,6 +236,12 @@ export class PersistenceManager {
     opts: { doRenderLog: () => void; dom: DomRefs }
   ): void {
     const d = data as Record<string, any>;
+    // Version check: v4 saves have no top-level version; v4.2 saves have version:'v4.2'.
+    // Throw on unknown future versions to surface incompatibility early.
+    const saveVersion = d.version as string | undefined;
+    if (saveVersion && saveVersion !== 'v4.2') {
+      throw new Error(`Save file version "${saveVersion}" is not compatible with v4.2`);
+    }
     world.running = false;
     world.grid.clear();
     world.agents.length = 0;


### PR DESCRIPTION
## Summary

- **VERSION** bumped to `4.2.0`
- **Top-level `version: 'v4.2'`** added to serialized state so future versions can detect save-file incompatibility
- **Pregnancy transfer fields serialized**: `useTransferMechanic`, `childNeeds`, `transferRate`, `gestationStartTick` are now persisted alongside existing v4 fields
- **Version check in `restore()`**: throws `Error` if `version` field is present and not `'v4.2'`; v4 saves (no top-level version) continue to load without error
- **OO → AD migration**: handled automatically by the gene registry during trait expression — no DNA rewriting needed

## Backward compatibility

| Save format | Result |
|---|---|
| v4 save (no top-level `version`) | Loads fine; pregnancy uses v4 fallback path |
| v4.2 save (`version: 'v4.2'`) | Loads fine; pregnancy uses transfer mechanic if saved with it |
| Future v5+ save | Throws with clear error message |

## Test plan

- [ ] Export save from v4.1.4, import in v4.2.0 — loads correctly, no errors
- [ ] Agents with active transfer-mechanic pregnancy survive a save/load cycle with correct `childNeeds` state
- [ ] A save file with `version: 'v5'` throws an error when loaded
- [ ] No TypeScript errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)