### PR TITLE
fix: show Reset button instead of disabling Start on autosave/import load

### DIFF
--- a/src/domains/ui/controls.ts
+++ b/src/domains/ui/controls.ts
@@ -235,7 +235,8 @@ export class Controls {
           PersistenceManager.restore(world, data, { doRenderLog, dom });
           if (buttons.btnPause) buttons.btnPause.disabled = true;
           if (buttons.btnResume) buttons.btnResume.disabled = false;
-          if (buttons.btnStart) buttons.btnStart.disabled = true;
+          if (buttons.btnStart) buttons.btnStart.style.display = 'none';
+          if (buttons.btnReset) buttons.btnReset.style.display = '';
           if (ranges.rngAgents) ranges.rngAgents.disabled = true;
           if (nums.numAgents) nums.numAgents.disabled = true;
         } catch (err) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,8 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       PersistenceManager.restore(world, autosaveData, { doRenderLog, dom });
       // Set button states so user can resume the restored session
-      if (dom.buttons.btnStart) dom.buttons.btnStart.disabled = true;
+      if (dom.buttons.btnStart) dom.buttons.btnStart.style.display = 'none';
+      if (dom.buttons.btnReset) dom.buttons.btnReset.style.display = '';
       if (dom.buttons.btnPause) dom.buttons.btnPause.disabled = true;
       if (dom.buttons.btnResume) dom.buttons.btnResume.disabled = false;
       if (dom.ranges.rngAgents) dom.ranges.rngAgents.disabled = true;


### PR DESCRIPTION
## Summary

- On autosave restore (page load), `btnStart` was disabled instead of hidden; now swaps to `btnReset`
- On file import, same bug — `btnStart.disabled = true` replaced with proper show/hide swap

The reset modal and confirm/cancel logic were already fully wired; this just surfaces it in the two load paths that were missed.

Closes #51

## Test plan
- [ ] Start a simulation, let it autosave (1 min), refresh the page — Reset button should appear instead of a greyed-out Start
- [ ] Import a save file — Reset button should appear instead of a greyed-out Start
- [ ] Click Reset → confirm in modal → Start button returns, controls re-enable

🤖 Generated with [Claude Code](https://claude.com/claude-code)