### PR TITLE
fix: reset button hidden by CSS default display:none

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,6 +348,11 @@
         padding: 24px;
         max-width: 340px;
         width: 90vw;
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        margin: 0;
       }
       #resetModal::backdrop {
         background: rgba(0,0,0,0.6);

--- a/src/domains/ui/controls.ts
+++ b/src/domains/ui/controls.ts
@@ -100,7 +100,7 @@ export class Controls {
       spawnAgents(Number(ranges.rngAgents?.value || 20));
       world.running = true;
       if (buttons.btnStart) buttons.btnStart.style.display = 'none';
-      if (buttons.btnReset) buttons.btnReset.style.display = '';
+      if (buttons.btnReset) buttons.btnReset.style.display = 'block';
       if (buttons.btnPause) buttons.btnPause.disabled = false;
       if (buttons.btnResume) buttons.btnResume.disabled = true;
       if (ranges.rngAgents) ranges.rngAgents.disabled = true;
@@ -236,7 +236,7 @@ export class Controls {
           if (buttons.btnPause) buttons.btnPause.disabled = true;
           if (buttons.btnResume) buttons.btnResume.disabled = false;
           if (buttons.btnStart) buttons.btnStart.style.display = 'none';
-          if (buttons.btnReset) buttons.btnReset.style.display = '';
+          if (buttons.btnReset) buttons.btnReset.style.display = 'block';
           if (ranges.rngAgents) ranges.rngAgents.disabled = true;
           if (nums.numAgents) nums.numAgents.disabled = true;
         } catch (err) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,7 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
       PersistenceManager.restore(world, autosaveData, { doRenderLog, dom });
       // Set button states so user can resume the restored session
       if (dom.buttons.btnStart) dom.buttons.btnStart.style.display = 'none';
-      if (dom.buttons.btnReset) dom.buttons.btnReset.style.display = '';
+      if (dom.buttons.btnReset) dom.buttons.btnReset.style.display = 'block';
       if (dom.buttons.btnPause) dom.buttons.btnPause.disabled = true;
       if (dom.buttons.btnResume) dom.buttons.btnResume.disabled = false;
       if (dom.ranges.rngAgents) dom.ranges.rngAgents.disabled = true;


### PR DESCRIPTION
## Summary

- `.btn-reset` CSS class has `display: none` — PR #52 used `style.display = ''` to show it, which only clears the inline style and falls back to the CSS rule (still hidden)
- Changed all 3 occurrences to `style.display = 'block'` to explicitly override the CSS default

Follows up on #52.

## Test plan
- [ ] Start a simulation → Reset button appears
- [ ] Refresh page (autosave restore) → Reset button appears
- [ ] Import a save file → Reset button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)