### PR TITLE
feat: plant life system v4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emoji-life",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "private": true,
   "scripts": {
     "build": "esbuild src/main.ts --bundle --outfile=dist/app.js",

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,4 +1,5 @@
 import type { LogCategory } from '../domains/action/types';
+import type { TreeVariant, ObstacleCategory } from '../domains/world/types';
 
 export const CELL_PX = 16;
 export let GRID_SIZE = 62;
@@ -78,10 +79,10 @@ export const IDLE_EMOJIS = {
 };
 
 export const FOOD_EMOJIS = {
-  hq: ['\u{1F954}', '\u{1F34E}', '\u{1F351}', '\u{1F33D}', '\u{1F345}'],
-  //    🥔           🍎           🍑           🌽           🍅
-  lq: ['\u{1F33F}', '\u{1F96C}', '\u{1F966}', '\u{1F340}'],
-  //    🌿           🥬           🥦           🍀
+  hq: ['\u{1F954}', '\u{1F33D}', '\u{1F345}'],
+  //    🥔           🌽           🍅
+  lq: ['\u{1F96C}', '\u{1F966}', '\u{1F340}'],
+  //    🥬           🥦           🍀
 } as const;
 
 export const OBSTACLE_EMOJIS = [
@@ -104,12 +105,45 @@ export const WORLD_EMOJIS = {
   egg: '\u{1F95A}',         // 🥚
 } as const;
 
-export const TREE_EMOJIS: readonly string[] = [
-  '\u{1F332}', // 🌲
-  '\u{1F333}', // 🌳
-  '\u{1F334}', // 🌴
-  '\u{1F384}', // 🎄
-];
+export const TREE_VARIANT_EMOJI: Record<TreeVariant, string> = {
+  tropical:  '\u{1F334}', // 🌴
+  evergreen: '\u{1F332}', // 🌲
+  regular:   '\u{1F333}', // 🌳
+};
+
+export const TREE_FRUIT_EMOJIS: readonly string[] = [
+  '\u{1F34E}', // 🍎 apple
+  '\u{1F350}', // 🍐 pear
+  '\u{1F34A}', // 🍊 orange
+  '\u{1F34B}', // 🍋 lemon
+  '\u{1F351}', // 🍑 peach
+  '\u{1F352}', // 🍒 cherry
+  '\u{1F34F}', // 🍏 green apple
+] as const;
+
+export const FLOWER_EMOJIS: readonly string[] = [
+  '\u{1F339}', // 🌹
+  '\u{1F33A}', // 🌺
+  '\u{1F337}', // 🌷
+  '\u{1F33B}', // 🌻
+  '\u{1FAB7}', // 🪻
+] as const;
+
+export const FARM_CROP_EMOJI = '\u{1F33E}'; // 🌾
+
+export const MEDICINE_EMOJI = '\u{1F33F}'; // 🌿
+
+export const CACTUS_EMOJI = '\u{1F335}'; // 🌵
+
+export const COCONUT_EMOJI = '\u{1F965}'; // 🥥
+
+export const OBSTACLE_CATEGORY: Record<string, ObstacleCategory> = {
+  '\u26F0\uFE0F':    'mountain', // ⛰️
+  '\u{1F5FB}':       'mountain', // 🗻
+  '\u{1F3D4}\uFE0F': 'mountain', // 🏔️
+  '\u{1FAA8}':       'rock',     // 🪨
+  '\u{1FAB5}':       'wood',     // 🪵
+};
 
 export const LOG_CATS: readonly LogCategory[] = [
   'talk',

--- a/src/domains/action/effects/resource-effects.ts
+++ b/src/domains/action/effects/resource-effects.ts
@@ -1,14 +1,17 @@
-import { key, log } from '../../../core/utils';
+import { key, log, manhattan } from '../../../core/utils';
+import { COCONUT_EMOJI, TREE_FRUIT_EMOJIS } from '../../../core/constants';
 import type { Agent } from '../../entity/agent';
 import type { World } from '../../world/world';
 import type { IActionState } from '../types';
+import { Spawner } from '../../simulation/spawner';
 
 // ── Constants ──
 const XP_PER_HARVEST = 2;
 const WATER_SHRINK_THRESHOLD = 0.25;
 const TREE_SEEDLING_CHANCE_ON_HARVEST = 0.10;
 const TREE_FOOD_CHANCE_ON_HARVEST = 0.05;
-const TREE_FOOD_REQUIRES_POOP_RADIUS = 3;
+const COCONUT_CAP_PER_TREE = 3;
+const COCONUT_RADIUS = 2;
 const FLAG_STORAGE_CAP = 30;
 
 // ── Harvest ──
@@ -17,9 +20,11 @@ export function onHarvestComplete(world: World, agent: Agent): void {
   const act = agent.action!;
   const tp = act.payload?.targetPos;
   if (!tp) return;
-  if (agent.inventoryFull()) return;
 
   const rt = act.payload?.resourceType || 'food_lq';
+
+  // Medicine bypasses inventory-full check (it's a status cure, not an item)
+  if (rt !== 'medicine' && agent.inventoryFull()) return;
 
   if (rt === 'food_hq' || rt === 'food_lq') {
     harvestFood(world, agent, tp);
@@ -27,6 +32,10 @@ export function onHarvestComplete(world: World, agent: Agent): void {
     harvestWater(world, agent, tp);
   } else if (rt === 'wood') {
     harvestWood(world, agent, tp);
+  } else if (rt === 'medicine') {
+    harvestMedicine(world, agent, tp);
+  } else if (rt === 'cactus') {
+    harvestCactus(world, agent, tp);
   }
 }
 
@@ -86,17 +95,55 @@ function harvestWood(world: World, agent: Agent, tp: { x: number; y: number }): 
   agent.addXp(XP_PER_HARVEST);
   log(world, 'harvest', `${agent.name} harvested wood`, agent.id, { x: tp.x, y: tp.y });
 
-  // Roll for seedling (10%) or food (5%)
+  // Roll for seedling (10%) or fruit (5%) — variant-specific
   const roll = Math.random();
   if (roll < TREE_SEEDLING_CHANCE_ON_HARVEST) {
-    world.events.emit('harvest:seedling-chance', { x: tree.x, y: tree.y });
+    Spawner.trySpawnSeedling(world, tree.x, tree.y, tree.variant);
   } else if (roll < TREE_SEEDLING_CHANCE_ON_HARVEST + TREE_FOOD_CHANCE_ON_HARVEST) {
-    world.events.emit('harvest:food-chance', { x: tree.x, y: tree.y, poopRadius: TREE_FOOD_REQUIRES_POOP_RADIUS });
+    if (tree.variant === 'tropical') {
+      let nearby = 0;
+      for (const [, fb] of world.foodBlocks) {
+        if (manhattan(tree.x, tree.y, fb.x, fb.y) <= COCONUT_RADIUS) nearby++;
+      }
+      if (nearby < COCONUT_CAP_PER_TREE) {
+        Spawner.trySpawnFruitNearTree(world, tree.x, tree.y, COCONUT_EMOJI);
+      }
+    } else if (tree.variant === 'regular') {
+      const emoji = TREE_FRUIT_EMOJIS[Math.floor(Math.random() * TREE_FRUIT_EMOJIS.length)];
+      Spawner.trySpawnFruitNearTree(world, tree.x, tree.y, emoji);
+    }
+    // Evergreen: no fruit
   }
 
   if (tree.units <= 0) {
     world.grid.treeBlocks.delete(k);
     world.deadMarkers.push({ cellX: tree.x, cellY: tree.y, cause: 'tree', msRemaining: 10000 });
+  }
+  checkLevelUp(world, agent);
+}
+
+function harvestMedicine(world: World, agent: Agent, tp: { x: number; y: number }): void {
+  const k = key(tp.x, tp.y);
+  const block = world.grid.medicineBlocks.get(k);
+  if (!block) return;
+  if (!agent.diseased) return; // no benefit if healthy
+  world.grid.medicineBlocks.delete(k);
+  agent.diseased = false;
+  agent.addXp(XP_PER_HARVEST);
+  log(world, 'harvest', `${agent.name} used medicine to cure disease`, agent.id, { x: tp.x, y: tp.y });
+  checkLevelUp(world, agent);
+}
+
+function harvestCactus(world: World, agent: Agent, tp: { x: number; y: number }): void {
+  const k = key(tp.x, tp.y);
+  const cactus = world.grid.cactusBlocks.get(k);
+  if (!cactus || cactus.units <= 0) return;
+  cactus.units--;
+  agent.addToInventory('water', 1);
+  agent.addXp(XP_PER_HARVEST);
+  log(world, 'harvest', `${agent.name} harvested water from cactus`, agent.id, { x: tp.x, y: tp.y });
+  if (cactus.units <= 0) {
+    world.grid.cactusBlocks.delete(k);
   }
   checkLevelUp(world, agent);
 }
@@ -163,3 +210,4 @@ function checkLevelUp(world: World, agent: Agent): void {
     log(world, 'level', `${agent.name} leveled to ${agent.level}`, agent.id, {});
   }
 }
+

--- a/src/domains/decision/context-builder.ts
+++ b/src/domains/decision/context-builder.ts
@@ -52,6 +52,24 @@ export class ContextBuilder {
       }
     }
 
+    // Scan for nearby medicine blocks (only relevant if diseased)
+    if (agent.diseased) {
+      for (const [, block] of world.grid.medicineBlocks) {
+        const dist = manhattan(agent.cellX, agent.cellY, block.x, block.y);
+        if (dist <= vr) {
+          nearbyResources.push({ type: 'medicine', pos: { x: block.x, y: block.y }, dist });
+        }
+      }
+    }
+
+    // Scan for nearby cactus blocks
+    for (const [, block] of world.grid.cactusBlocks) {
+      const dist = manhattan(agent.cellX, agent.cellY, block.x, block.y);
+      if (dist <= vr) {
+        nearbyResources.push({ type: 'cactus', pos: { x: block.x, y: block.y }, dist });
+      }
+    }
+
     // Nearby poop blocks
     for (const [, block] of world.grid.poopBlocks) {
       const dist = manhattan(agent.cellX, agent.cellY, block.x, block.y);

--- a/src/domains/decision/decision-engine.ts
+++ b/src/domains/decision/decision-engine.ts
@@ -213,7 +213,11 @@ function resolveTarget(
       const adjRes = ctx.nearbyResources.filter(r => r.dist <= 1);
       if (!adjRes.length) return null;
       const r = adjRes[0];
-      const resourceType = r.type === 'food' ? 'food_lq' : r.type;
+      let resourceType: string;
+      if (r.type === 'food') resourceType = 'food_lq';
+      else if (r.type === 'medicine') resourceType = 'medicine';
+      else if (r.type === 'cactus') resourceType = 'cactus';
+      else resourceType = r.type;
       return { targetPos: { x: r.pos.x, y: r.pos.y }, resourceType } as { targetPos: { x: number; y: number }; resourceType: string } & { targetId?: string };
     }
     case 'pickup': {

--- a/src/domains/decision/types.ts
+++ b/src/domains/decision/types.ts
@@ -12,7 +12,7 @@ export interface NearbyAgent {
 }
 
 export interface NearbyResource {
-  readonly type: 'food' | 'water' | 'wood' | 'seedling';
+  readonly type: 'food' | 'water' | 'wood' | 'seedling' | 'medicine' | 'cactus';
   readonly pos: IPosition;
   readonly dist: number;
 }

--- a/src/domains/persistence/persistence-manager.ts
+++ b/src/domains/persistence/persistence-manager.ts
@@ -1,4 +1,4 @@
-import { CELL_PX, GRID_SIZE } from '../../core/constants';
+import { CELL_PX, GRID_SIZE, OBSTACLE_CATEGORY, TREE_VARIANT_EMOJI } from '../../core/constants';
 import { key, rndi, RingLog } from '../../core/utils';
 import type { ResourceMemoryType, IResourceMemoryEntry } from '../../core/types';
 import type { World } from '../world';
@@ -7,7 +7,7 @@ import { Agent } from '../entity/agent';
 import { Genome } from '../genetics';
 import { Faction, FactionManager } from '../faction';
 
-const VERSION = '4.2.0';
+const VERSION = '4.3.0';
 
 // Inlined TUNE constants
 const FARM_MAX_SPAWNS = 12;
@@ -145,7 +145,7 @@ export class PersistenceManager {
       } : null,
     }));
     return {
-      version: 'v4.2',
+      version: 'v4.3',
       meta: { version: VERSION, savedAt: Date.now() },
       grid: { CELL: CELL_PX, GRID: GRID_SIZE },
       state: {
@@ -172,6 +172,9 @@ export class PersistenceManager {
       poopBlocks: [...world.poopBlocks.values()],
       saltWaterBlocks: [...world.saltWaterBlocks.values()],
       eggs: [...world.eggs.values()],
+      medicineBlocks: [...world.medicineBlocks.values()],
+      flowerBlocks: [...world.flowerBlocks.values()],
+      cactusBlocks: [...world.cactusBlocks.values()],
       agents,
       familyRegistry: world.familyRegistry.getAllFamiliesIncludingDead().map(f => ({
         familyName: f.familyName,
@@ -239,8 +242,8 @@ export class PersistenceManager {
     // Version check: v4 saves have no top-level version; v4.2 saves have version:'v4.2'.
     // Throw on unknown future versions to surface incompatibility early.
     const saveVersion = d.version as string | undefined;
-    if (saveVersion && saveVersion !== 'v4.2') {
-      throw new Error(`Save file version "${saveVersion}" is not compatible with v4.2`);
+    if (saveVersion && saveVersion !== 'v4.2' && saveVersion !== 'v4.3') {
+      throw new Error(`Save file version "${saveVersion}" is not compatible with v4.3`);
     }
     world.running = false;
     world.grid.clear();
@@ -273,7 +276,12 @@ export class PersistenceManager {
       world.flagCells.add(key(fl.x, fl.y));
     }
     for (const o of d.obstacles || d.walls || []) {
-      const obs = { ...o, emoji: o.emoji || '🪨' };
+      const emoji = o.emoji || '\u{1FAA8}';
+      const obs = {
+        ...o,
+        emoji,
+        category: o.category ?? (OBSTACLE_CATEGORY[emoji] ?? 'rock'),
+      };
       world.obstacles.set(key(o.x, o.y), obs);
       if (o.size === '2x2') {
         world.obstacles.set(key(o.x + 1, o.y), obs);
@@ -314,9 +322,13 @@ export class PersistenceManager {
     }
     // Restore tree blocks
     for (const tb of d.treeBlocks || []) {
+      const emoji = tb.emoji ?? TREE_VARIANT_EMOJI.regular;
+      const variant = tb.variant ?? variantFromEmoji(emoji);
       world.treeBlocks.set(key(tb.x, tb.y), {
         id: tb.id, x: tb.x, y: tb.y,
-        emoji: tb.emoji, units: tb.units ?? 3,
+        emoji,
+        variant,
+        units: tb.units ?? 3,
         maxUnits: tb.maxUnits ?? 3,
         ageTotalMs: tb.ageTotalMs ?? 0,
         maxAgeMs: tb.maxAgeMs ?? rndi(TREE_MAX_AGE_RANGE[0], TREE_MAX_AGE_RANGE[1]),
@@ -326,6 +338,7 @@ export class PersistenceManager {
     for (const s of d.seedlings || []) {
       world.seedlings.set(key(s.x, s.y), {
         id: s.id, x: s.x, y: s.y,
+        variant: s.variant ?? 'regular',
         plantedAtTick: s.plantedAtTick ?? 0,
         growthDurationMs: s.growthDurationMs ?? 60000,
         growthElapsedMs: s.growthElapsedMs ?? 0,
@@ -365,6 +378,26 @@ export class PersistenceManager {
         x: eg.x,
         y: eg.y,
         hatchTimerMs: eg.hatchTimerMs ?? 0,
+      });
+    }
+    // Restore medicine blocks
+    for (const m of d.medicineBlocks || []) {
+      world.medicineBlocks.set(key(m.x, m.y), { id: m.id, x: m.x, y: m.y });
+    }
+    // Restore flower blocks
+    for (const f of d.flowerBlocks || []) {
+      world.flowerBlocks.set(key(f.x, f.y), {
+        id: f.id, x: f.x, y: f.y,
+        emoji: f.emoji,
+        lifespanMs: f.lifespanMs ?? 120000,
+      });
+    }
+    // Restore cactus blocks
+    for (const c of d.cactusBlocks || []) {
+      world.cactusBlocks.set(key(c.x, c.y), {
+        id: c.id, x: c.x, y: c.y,
+        units: c.units ?? 1,
+        maxUnits: c.maxUnits ?? 1,
       });
     }
     // Recompute terrain moisture from restored water/saltwater state
@@ -519,4 +552,12 @@ export class PersistenceManager {
       }
     });
   }
+}
+
+import type { TreeVariant } from '../world/types';
+
+function variantFromEmoji(emoji: string): TreeVariant {
+  if (emoji === TREE_VARIANT_EMOJI.tropical) return 'tropical';
+  if (emoji === TREE_VARIANT_EMOJI.evergreen) return 'evergreen';
+  return 'regular'; // default for 🌳, 🎄, or unknown
 }

--- a/src/domains/rendering/renderer.ts
+++ b/src/domains/rendering/renderer.ts
@@ -1,4 +1,5 @@
-import { CELL_PX, GRID_SIZE, COLORS, AGENT_EMOJIS, IDLE_EMOJIS, WORLD_EMOJIS, FOOD_EMOJIS } from '../../core/constants';
+import { CELL_PX, GRID_SIZE, COLORS, AGENT_EMOJIS, IDLE_EMOJIS, WORLD_EMOJIS, FOOD_EMOJIS, MEDICINE_EMOJI, CACTUS_EMOJI } from '../../core/constants';
+import { FLOWER_LIFESPAN_RANGE } from '../simulation/spawner';
 import { getIdleEmoji } from '../../core/utils';
 import type { TerrainField } from '../world/terrain-field';
 import type { World } from '../world';
@@ -46,8 +47,11 @@ const LOD_EGG     = '#f5e6c8';
 const LOD_POOP    = '#6b4226';
 const LOD_FOOD    = '#c88040';
 const LOD_LOOT    = '#c9a83f';
-const LOD_FARM    = '#b8860b';
+const LOD_FARM     = '#b8860b';
 const LOD_OBSTACLE = '#888888';
+const LOD_MEDICINE = '#4a8c5c';
+const LOD_FLOWER   = '#cc6699';
+const LOD_CACTUS   = '#2d6b3e';
 
 export class Renderer {
   private readonly _emojiCache = new EmojiCache();
@@ -118,6 +122,9 @@ export class Renderer {
     this._drawEggs(ctx, world, vb, lod);
     this._drawPoopBlocks(ctx, world, vb, lod);
     this._drawFoodBlocks(ctx, world, vb, lod);
+    this._drawMedicineBlocks(ctx, world, vb, lod);
+    this._drawFlowerBlocks(ctx, world, vb, lod);
+    this._drawCactusBlocks(ctx, world, vb, lod);
     this._drawLootBags(ctx, world, vb, lod);
     this._drawFarms(ctx, world, vb, lod);
     this._drawObstacles(ctx, world, vb, lod);
@@ -317,7 +324,7 @@ export class Renderer {
   }
 
   private _drawTreeBlocks(ctx: CanvasRenderingContext2D, world: World, vb: ViewBounds, lod: boolean): void {
-    // Rebuild near-water lookup when tree or water counts change
+    // Rebuild near-water/sustain lookup when tree or water counts change
     const treeCount = world.treeBlocks.size;
     const waterCount = world.waterBlocks.size;
     if (treeCount !== this._cachedTreeCount || waterCount !== this._cachedWaterCount) {
@@ -325,12 +332,25 @@ export class Renderer {
       this._cachedWaterCount = waterCount;
       this._treeNearWater.clear();
       for (const tree of world.treeBlocks.values()) {
+        const k = `${tree.x},${tree.y}`;
+        let near = false;
         for (const wb of world.waterBlocks.values()) {
-          if (Math.abs(tree.x - wb.x) + Math.abs(tree.y - wb.y) <= 5) {
-            this._treeNearWater.add(`${tree.x},${tree.y}`);
-            break;
+          if (Math.abs(tree.x - wb.x) + Math.abs(tree.y - wb.y) <= 5) { near = true; break; }
+        }
+        if (!near && tree.variant === 'tropical') {
+          for (const sw of world.saltWaterBlocks.values()) {
+            if (Math.abs(tree.x - sw.x) + Math.abs(tree.y - sw.y) <= 5) { near = true; break; }
           }
         }
+        if (!near && tree.variant === 'evergreen') {
+          for (const [, obs] of world.obstacles) {
+            if (obs.category === 'mountain' &&
+                Math.abs(tree.x - obs.x) + Math.abs(tree.y - obs.y) <= 3) {
+              near = true; break;
+            }
+          }
+        }
+        if (near) this._treeNearWater.add(k);
       }
     }
 
@@ -403,6 +423,53 @@ export class Renderer {
         this._fillCell(ctx, fb.x, fb.y, LOD_FOOD, 4);
       } else {
         this._drawCellEmoji(ctx, fb.x, fb.y, fb.emoji || FOOD_EMOJIS.lq[0], CELL_PX / 2);
+      }
+      ctx.globalAlpha = 1;
+    }
+  }
+
+  private _drawMedicineBlocks(ctx: CanvasRenderingContext2D, world: World, vb: ViewBounds, lod: boolean): void {
+    for (const [, block] of world.medicineBlocks) {
+      if (!this._inView(block.x, block.y, vb)) continue;
+      const px = block.x * CELL_PX;
+      const py = block.y * CELL_PX;
+      if (lod) {
+        ctx.fillStyle = LOD_MEDICINE;
+        ctx.fillRect(px + 4, py + 4, CELL_PX - 8, CELL_PX - 8);
+      } else {
+        this._drawCellEmoji(ctx, block.x, block.y, MEDICINE_EMOJI, CELL_PX / 2);
+      }
+    }
+  }
+
+  private _drawFlowerBlocks(ctx: CanvasRenderingContext2D, world: World, vb: ViewBounds, lod: boolean): void {
+    const fadeThreshold = FLOWER_LIFESPAN_RANGE[1] * 0.2;
+    for (const [, flower] of world.flowerBlocks) {
+      if (!this._inView(flower.x, flower.y, vb)) continue;
+      const fade = flower.lifespanMs < fadeThreshold
+        ? Math.max(0, flower.lifespanMs / fadeThreshold)
+        : 1;
+      ctx.globalAlpha = fade;
+      if (lod) {
+        ctx.fillStyle = LOD_FLOWER;
+        ctx.fillRect(flower.x * CELL_PX + 5, flower.y * CELL_PX + 5, CELL_PX - 10, CELL_PX - 10);
+      } else {
+        this._drawCellEmoji(ctx, flower.x, flower.y, flower.emoji, CELL_PX / 2);
+      }
+      ctx.globalAlpha = 1;
+    }
+  }
+
+  private _drawCactusBlocks(ctx: CanvasRenderingContext2D, world: World, vb: ViewBounds, lod: boolean): void {
+    for (const [, cactus] of world.cactusBlocks) {
+      if (!this._inView(cactus.x, cactus.y, vb)) continue;
+      const alpha = 0.4 + 0.6 * (cactus.units / cactus.maxUnits);
+      ctx.globalAlpha = alpha;
+      if (lod) {
+        ctx.fillStyle = LOD_CACTUS;
+        ctx.fillRect(cactus.x * CELL_PX, cactus.y * CELL_PX, CELL_PX, CELL_PX);
+      } else {
+        this._drawCellEmoji(ctx, cactus.x, cactus.y, CACTUS_EMOJI);
       }
       ctx.globalAlpha = 1;
     }

--- a/src/domains/simulation/agent-updater.ts
+++ b/src/domains/simulation/agent-updater.ts
@@ -173,7 +173,7 @@ function scanVision(world: World, agent: Agent): void {
       if (world.foodBlocks.has(k) || world.seedlings.has(k)) {
         agent.rememberResource('food', x, y, world.tick);
       }
-      if (world.waterBlocks.has(k)) {
+      if (world.waterBlocks.has(k) || world.cactusBlocks.has(k)) {
         agent.rememberResource('water', x, y, world.tick);
       }
       if (world.treeBlocks.has(k)) {

--- a/src/domains/simulation/spawner.ts
+++ b/src/domains/simulation/spawner.ts
@@ -375,7 +375,7 @@ export class Spawner {
       // Density check for capped variants
       if (s.variant === 'tropical' || s.variant === 'regular') {
         const cap = s.variant === 'tropical' ? TROPICAL_DENSITY_CAP : REGULAR_DENSITY_CAP;
-        const count = countVariantInArea(world, s.x, s.y, s.variant, 1); // 3×3 = radius 1
+        const count = countVariantInArea(world, s.x, s.y, s.variant, 2); // 5×5 = radius 2
         if (count >= cap) {
           world.seedlings.delete(k); // silently die, no death marker
           continue;

--- a/src/domains/simulation/spawner.ts
+++ b/src/domains/simulation/spawner.ts
@@ -1,6 +1,11 @@
-import { GRID_SIZE, TICK_MS, FOOD_EMOJIS, TREE_EMOJIS } from '../../core/constants';
+import {
+  GRID_SIZE, TICK_MS, FOOD_EMOJIS,
+  TREE_VARIANT_EMOJI, TREE_FRUIT_EMOJIS, FLOWER_EMOJIS,
+  FARM_CROP_EMOJI, MEDICINE_EMOJI, CACTUS_EMOJI, COCONUT_EMOJI,
+} from '../../core/constants';
 import { key, manhattan, rndi, log, uuid } from '../../core/utils';
 import type { World } from '../world/world';
+import type { TreeVariant } from '../world/types';
 import { AgentFactory } from '../entity/agent-factory';
 
 // ── Inlined TUNE constants ──
@@ -23,6 +28,26 @@ const TREE_WATER_REQUIRED_FOR_SEEDLING = 5;
 const TREE_POOP_BOOST_SEEDLING_RADIUS = 3;
 const TREE_SEEDLING_NEAR_WATER_CHANCE = 0.0005;
 
+// ── Tree variant tuning ──
+const TROPICAL_DENSITY_CAP = 2;          // max 🌴 in 3×3 area
+const REGULAR_DENSITY_CAP = 3;           // max 🌳 in 3×3 area
+
+// ── New plant tuning ──
+const MEDICINE_SPAWN_CHANCE = 0.0003;    // per mountain obstacle per tick
+const MEDICINE_SPAWN_RADIUS = 3;
+
+const FLOWER_SPAWN_CHANCE = 0.0002;      // per fresh-water block per tick
+const FLOWER_SPAWN_RADIUS = 3;
+const FLOWER_LIFESPAN_RANGE: [number, number] = [100000, 140000]; // ~100-140s
+
+const CACTUS_SPAWN_CHANCE = 0.0001;      // global roll per tick
+const CACTUS_MIN_WATER_DISTANCE = 15;
+const CACTUS_UNITS = 1;
+const CACTUS_MAX_UNITS = 1;
+
+const COCONUT_CAP_PER_TREE = 3;         // max coconuts within COCONUT_RADIUS cells
+const COCONUT_RADIUS = 2;
+
 const EGG_HATCH_TIME_MS = 60000;
 const EGG_SPAWN_CHANCE_PER_LARGE_WATER = 0.0002;
 
@@ -44,8 +69,28 @@ function randomFoodEmoji(quality: 'hq' | 'lq'): string {
   return arr[Math.floor(Math.random() * arr.length)];
 }
 
-function randomTreeEmoji(): string {
-  return TREE_EMOJIS[Math.floor(Math.random() * TREE_EMOJIS.length)];
+function randomVariant(): TreeVariant {
+  const variants: TreeVariant[] = ['tropical', 'evergreen', 'regular'];
+  return variants[Math.floor(Math.random() * variants.length)];
+}
+
+function countVariantInArea(world: World, cx: number, cy: number, variant: TreeVariant, radius: number): number {
+  let count = 0;
+  for (let dx = -radius; dx <= radius; dx++) {
+    for (let dy = -radius; dy <= radius; dy++) {
+      const tree = world.treeBlocks.get(key(cx + dx, cy + dy));
+      if (tree && tree.variant === variant) count++;
+    }
+  }
+  return count;
+}
+
+function countFoodInRadius(world: World, cx: number, cy: number, radius: number): number {
+  let count = 0;
+  for (const [, fb] of world.foodBlocks) {
+    if (manhattan(cx, cy, fb.x, fb.y) <= radius) count++;
+  }
+  return count;
 }
 
 // ── Public API ──
@@ -116,7 +161,7 @@ export class Spawner {
         const units = rndi(FOOD_HQ_UNITS[0], FOOD_HQ_UNITS[1]);
         world.foodBlocks.set(key(x, y), {
           id: uuid(), x, y,
-          emoji: randomFoodEmoji('hq'),
+          emoji: FARM_CROP_EMOJI,
           quality: 'hq', units, maxUnits: units,
         });
         spawned = true;
@@ -195,7 +240,8 @@ export class Spawner {
 
   // ── Tree spawning ──
 
-  static addTree(world: World): boolean {
+  static addTree(world: World, variant?: TreeVariant): boolean {
+    const v = variant ?? randomVariant();
     for (let attempt = 0; attempt < 500; attempt++) {
       const x = rndi(0, GRID_SIZE - 1);
       const y = rndi(0, GRID_SIZE - 1);
@@ -204,7 +250,8 @@ export class Spawner {
       const maxAgeMs = rndi(TREE_MAX_AGE_RANGE[0], TREE_MAX_AGE_RANGE[1]);
       world.treeBlocks.set(key(x, y), {
         id: uuid(), x, y,
-        emoji: randomTreeEmoji(),
+        emoji: TREE_VARIANT_EMOJI[v],
+        variant: v,
         units, maxUnits: units,
         ageTotalMs: 0, maxAgeMs,
       });
@@ -222,12 +269,21 @@ export class Spawner {
 
   // ── Seedling / tree passive spawns ──
 
-  static trySpawnSeedling(world: World, originX: number, originY: number): boolean {
+  static trySpawnSeedling(world: World, originX: number, originY: number, variant: TreeVariant): boolean {
+    // Check for water — tropical can use saltwater too
     let nearWater = false;
     for (const wb of world.waterBlocks.values()) {
       if (manhattan(originX, originY, wb.x, wb.y) <= TREE_WATER_REQUIRED_FOR_SEEDLING) {
         nearWater = true;
         break;
+      }
+    }
+    if (!nearWater && variant === 'tropical') {
+      for (const sw of world.saltWaterBlocks.values()) {
+        if (manhattan(originX, originY, sw.x, sw.y) <= TREE_WATER_REQUIRED_FOR_SEEDLING) {
+          nearWater = true;
+          break;
+        }
       }
     }
     if (!nearWater) return false;
@@ -241,6 +297,7 @@ export class Spawner {
       const dur = rndi(TREE_SEEDLING_GROWTH_RANGE[0], TREE_SEEDLING_GROWTH_RANGE[1]);
       world.seedlings.set(key(x, y), {
         id: uuid(), x, y,
+        variant,
         plantedAtTick: world.tick,
         growthDurationMs: dur,
         growthElapsedMs: 0,
@@ -250,38 +307,88 @@ export class Spawner {
     return false;
   }
 
-  static trySpawnFoodNearTree(world: World, treeX: number, treeY: number): boolean {
+  static trySpawnFruitNearTree(world: World, treeX: number, treeY: number, emoji: string): boolean {
     const r = TREE_FOOD_RADIUS;
     for (let attempt = 0; attempt < 10; attempt++) {
       const x = treeX + rndi(-r, r);
       const y = treeY + rndi(-r, r);
       if (x < 0 || y < 0 || x >= GRID_SIZE || y >= GRID_SIZE) continue;
       if (world.grid.isCellOccupied(x, y)) continue;
-      return Spawner.addCrop(world, x, y);
+      const units = rndi(FOOD_HQ_UNITS[0], FOOD_HQ_UNITS[1]);
+      world.foodBlocks.set(key(x, y), {
+        id: uuid(), x, y,
+        emoji,
+        quality: 'hq',
+        units, maxUnits: units,
+      });
+      return true;
     }
     return false;
   }
 
   static tickSeedlings(world: World): void {
     const toConvert: string[] = [];
+    const toDie: string[] = [];
+
     for (const [k, s] of world.seedlings) {
+      // Check water proximity — tropical can use saltwater too
       let nearWater = false;
       for (const wb of world.waterBlocks.values()) {
-        if (manhattan(s.x, s.y, wb.x, wb.y) <= 5) { nearWater = true; break; }
+        if (manhattan(s.x, s.y, wb.x, wb.y) <= TREE_WATER_REQUIRED_FOR_SEEDLING) {
+          nearWater = true;
+          break;
+        }
       }
-      s.growthElapsedMs += nearWater ? TICK_MS : TICK_MS / 100;
+      if (!nearWater && s.variant === 'tropical') {
+        for (const sw of world.saltWaterBlocks.values()) {
+          if (manhattan(s.x, s.y, sw.x, sw.y) <= TREE_WATER_REQUIRED_FOR_SEEDLING) {
+            nearWater = true;
+            break;
+          }
+        }
+      }
+
+      if (nearWater) {
+        s.growthElapsedMs += TICK_MS;
+      } else {
+        // Without water, seedling declines — reverse progress at double the slow rate
+        s.growthElapsedMs -= TICK_MS * 2;
+        if (s.growthElapsedMs <= -(s.growthDurationMs * 0.5)) {
+          toDie.push(k);
+          continue;
+        }
+      }
+
       if (s.growthElapsedMs >= s.growthDurationMs) {
         toConvert.push(k);
       }
     }
+
+    // Silent deaths (no marker)
+    for (const k of toDie) {
+      world.seedlings.delete(k);
+    }
+
     for (const k of toConvert) {
       const s = world.seedlings.get(k)!;
+
+      // Density check for capped variants
+      if (s.variant === 'tropical' || s.variant === 'regular') {
+        const cap = s.variant === 'tropical' ? TROPICAL_DENSITY_CAP : REGULAR_DENSITY_CAP;
+        const count = countVariantInArea(world, s.x, s.y, s.variant, 1); // 3×3 = radius 1
+        if (count >= cap) {
+          world.seedlings.delete(k); // silently die, no death marker
+          continue;
+        }
+      }
+
       world.seedlings.delete(k);
       const units = rndi(TREE_UNIT_RANGE[0], TREE_UNIT_RANGE[1]);
       const maxAgeMs = rndi(TREE_MAX_AGE_RANGE[0], TREE_MAX_AGE_RANGE[1]);
       world.treeBlocks.set(k, {
         id: uuid(), x: s.x, y: s.y,
-        emoji: randomTreeEmoji(),
+        emoji: TREE_VARIANT_EMOJI[s.variant],
+        variant: s.variant,
         units, maxUnits: units,
         ageTotalMs: 0, maxAgeMs,
       });
@@ -305,6 +412,7 @@ export class Spawner {
           const dur = rndi(TREE_SEEDLING_GROWTH_RANGE[0], TREE_SEEDLING_GROWTH_RANGE[1]);
           world.seedlings.set(key(x, y), {
             id: uuid(), x, y,
+            variant: randomVariant(),  // random since no parent
             plantedAtTick: world.tick,
             growthDurationMs: dur,
             growthElapsedMs: 0,
@@ -335,9 +443,19 @@ export class Spawner {
       if (hydrated) seedlingChance *= 3;
       if (nearPoop) seedlingChance *= 2;
       if (Math.random() < seedlingChance) {
-        Spawner.trySpawnSeedling(world, tree.x, tree.y);
+        Spawner.trySpawnSeedling(world, tree.x, tree.y, tree.variant);
       } else if (nearPoop && Math.random() < TREE_FOOD_PASSIVE_CHANCE) {
-        Spawner.trySpawnFoodNearTree(world, tree.x, tree.y);
+        // Variant-specific fruit
+        if (tree.variant === 'tropical') {
+          const nearbyCoconuts = countFoodInRadius(world, tree.x, tree.y, COCONUT_RADIUS);
+          if (nearbyCoconuts < COCONUT_CAP_PER_TREE) {
+            Spawner.trySpawnFruitNearTree(world, tree.x, tree.y, COCONUT_EMOJI);
+          }
+        } else if (tree.variant === 'regular') {
+          const emoji = TREE_FRUIT_EMOJIS[Math.floor(Math.random() * TREE_FRUIT_EMOJIS.length)];
+          Spawner.trySpawnFruitNearTree(world, tree.x, tree.y, emoji);
+        }
+        // Evergreen: no fruit
       }
     }
   }
@@ -465,11 +583,8 @@ export class Spawner {
   }
 
   // ── Egg spawning and hatching ──
-  // Eggs spawn from large water blocks (0.0002 chance/tick/large block), continuously,
-  // regardless of agent count.
 
   static tickEggs(world: World): void {
-    // Spawn eggs from large water blocks
     const seenWater = new Set<string>();
     for (const wb of world.waterBlocks.values()) {
       if (seenWater.has(wb.id)) continue;
@@ -477,7 +592,6 @@ export class Spawner {
       if (wb.size !== 'large') continue;
       if (Math.random() >= EGG_SPAWN_CHANCE_PER_LARGE_WATER) continue;
 
-      // Place egg adjacent to a water cell
       for (const cell of wb.cells) {
         const adj: [number, number][] = [
           [cell.x + 1, cell.y], [cell.x - 1, cell.y],
@@ -499,7 +613,6 @@ export class Spawner {
       }
     }
 
-    // Hatch eggs
     const toHatch: string[] = [];
     for (const [k, egg] of world.eggs) {
       egg.hatchTimerMs -= TICK_MS;
@@ -519,6 +632,91 @@ export class Spawner {
     }
   }
 
+  // ── Medicine spawning ──
+
+  static tickMedicineSpawns(world: World): void {
+    const seen = new Set<string>();
+    for (const [, obs] of world.obstacles) {
+      if (seen.has(obs.id)) continue;
+      seen.add(obs.id);
+      if (obs.category !== 'mountain') continue;
+      if (Math.random() >= MEDICINE_SPAWN_CHANCE) continue;
+
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const dx = rndi(-MEDICINE_SPAWN_RADIUS, MEDICINE_SPAWN_RADIUS);
+        const dy = rndi(-MEDICINE_SPAWN_RADIUS, MEDICINE_SPAWN_RADIUS);
+        const x = obs.x + dx;
+        const y = obs.y + dy;
+        if (x < 0 || y < 0 || x >= GRID_SIZE || y >= GRID_SIZE) continue;
+        if (world.grid.isCellOccupied(x, y)) continue;
+        world.medicineBlocks.set(key(x, y), { id: uuid(), x, y });
+        break;
+      }
+    }
+  }
+
+  // ── Flower spawning ──
+
+  static tickFlowerSpawns(world: World): void {
+    const seen = new Set<string>();
+    for (const [, wb] of world.waterBlocks) {
+      if (seen.has(wb.id)) continue;
+      seen.add(wb.id);
+      if (Math.random() >= FLOWER_SPAWN_CHANCE) continue;
+
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const dx = rndi(-FLOWER_SPAWN_RADIUS, FLOWER_SPAWN_RADIUS);
+        const dy = rndi(-FLOWER_SPAWN_RADIUS, FLOWER_SPAWN_RADIUS);
+        const x = wb.x + dx;
+        const y = wb.y + dy;
+        if (x < 0 || y < 0 || x >= GRID_SIZE || y >= GRID_SIZE) continue;
+        if (world.grid.isCellOccupied(x, y)) continue;
+        const emoji = FLOWER_EMOJIS[Math.floor(Math.random() * FLOWER_EMOJIS.length)];
+        world.flowerBlocks.set(key(x, y), {
+          id: uuid(), x, y, emoji,
+          lifespanMs: rndi(FLOWER_LIFESPAN_RANGE[0], FLOWER_LIFESPAN_RANGE[1]),
+        });
+        break;
+      }
+    }
+  }
+
+  // ── Cactus spawning ──
+
+  static tickCactusSpawns(world: World): void {
+    if (Math.random() >= CACTUS_SPAWN_CHANCE) return;
+
+    for (let attempt = 0; attempt < 50; attempt++) {
+      const x = rndi(0, GRID_SIZE - 1);
+      const y = rndi(0, GRID_SIZE - 1);
+      if (world.grid.isCellOccupied(x, y)) continue;
+
+      let tooClose = false;
+      for (const wb of world.waterBlocks.values()) {
+        if (manhattan(x, y, wb.x, wb.y) < CACTUS_MIN_WATER_DISTANCE) {
+          tooClose = true;
+          break;
+        }
+      }
+      if (!tooClose) {
+        for (const sw of world.saltWaterBlocks.values()) {
+          if (manhattan(x, y, sw.x, sw.y) < CACTUS_MIN_WATER_DISTANCE) {
+            tooClose = true;
+            break;
+          }
+        }
+      }
+      if (tooClose) continue;
+
+      world.cactusBlocks.set(key(x, y), {
+        id: uuid(), x, y,
+        units: CACTUS_UNITS,
+        maxUnits: CACTUS_MAX_UNITS,
+      });
+      break;
+    }
+  }
+
   // ── Combined tick ──
 
   static tick(world: World): void {
@@ -528,5 +726,11 @@ export class Spawner {
     Spawner.tickClouds(world);
     Spawner.tickSeedlingNearWater(world);
     Spawner.tickEggs(world);
+    Spawner.tickMedicineSpawns(world);
+    Spawner.tickFlowerSpawns(world);
+    Spawner.tickCactusSpawns(world);
   }
 }
+
+// Export for renderer use
+export { FLOWER_LIFESPAN_RANGE };

--- a/src/domains/simulation/world-updater.ts
+++ b/src/domains/simulation/world-updater.ts
@@ -1,5 +1,5 @@
-import { TICK_MS } from '../../core/constants';
-import { key, log } from '../../core/utils';
+import { TICK_MS, OBSTACLE_CATEGORY } from '../../core/constants';
+import { key, log, manhattan } from '../../core/utils';
 import type { World } from '../world/world';
 
 // ── Inlined TUNE constants ──
@@ -8,6 +8,10 @@ const WATER_BASE_DECAY_PER_TICK = 0.008;
 const WATER_SHRINK_THRESHOLD = 0.25;
 
 const TERRAIN_UPDATE_INTERVAL = 40; // ticks (~10 seconds)
+
+const TREE_WATER_SUSTAIN_RANGE = 5;      // manhattan distance for water sustain
+const TREE_DECLINE_RATE_PER_TICK = 0.01; // units lost per tick when dehydrated
+const EVERGREEN_MOUNTAIN_RANGE = 3;      // mountain sustain range for evergreens
 
 export class WorldUpdater {
 
@@ -65,6 +69,70 @@ export class WorldUpdater {
     }
   }
 
+  // ── Tree dehydration / decline ──
+
+  static tickTreeSustain(world: World): void {
+    const toRemove: string[] = [];
+
+    for (const [k, tree] of world.treeBlocks) {
+      let sustained = false;
+
+      // Fresh water check (all variants)
+      for (const wb of world.waterBlocks.values()) {
+        if (manhattan(tree.x, tree.y, wb.x, wb.y) <= TREE_WATER_SUSTAIN_RANGE) {
+          sustained = true;
+          break;
+        }
+      }
+
+      // Saltwater check (tropical only)
+      if (!sustained && tree.variant === 'tropical') {
+        for (const sw of world.saltWaterBlocks.values()) {
+          if (manhattan(tree.x, tree.y, sw.x, sw.y) <= TREE_WATER_SUSTAIN_RANGE) {
+            sustained = true;
+            break;
+          }
+        }
+      }
+
+      // Mountain sustain (evergreen adults only)
+      if (!sustained && tree.variant === 'evergreen') {
+        for (const [, obs] of world.obstacles) {
+          if ((obs.category === 'mountain' || OBSTACLE_CATEGORY[obs.emoji] === 'mountain') &&
+              manhattan(tree.x, tree.y, obs.x, obs.y) <= EVERGREEN_MOUNTAIN_RANGE) {
+            sustained = true;
+            break;
+          }
+        }
+      }
+
+      if (!sustained) {
+        tree.units -= TREE_DECLINE_RATE_PER_TICK;
+        if (tree.units <= 0) {
+          toRemove.push(k);
+        }
+      }
+    }
+
+    for (const k of toRemove) {
+      const tree = world.treeBlocks.get(k)!;
+      world.treeBlocks.delete(k);
+      world.deadMarkers.push({ cellX: tree.x, cellY: tree.y, cause: 'tree', msRemaining: 10000 });
+      log(world, 'death', `Tree @${tree.x},${tree.y} died of dehydration`, null, { x: tree.x, y: tree.y });
+    }
+  }
+
+  // ── Flower lifespan decay ──
+
+  static tickFlowerDecay(world: World): void {
+    for (const [k, flower] of world.flowerBlocks) {
+      flower.lifespanMs -= TICK_MS;
+      if (flower.lifespanMs <= 0) {
+        world.flowerBlocks.delete(k);
+      }
+    }
+  }
+
   // ── Block decay (delegates to BlockManager) ──
 
   static tickBlockDecay(world: World): void {
@@ -77,6 +145,8 @@ export class WorldUpdater {
     WorldUpdater.tickWaterDecay(world);
     WorldUpdater.tickTerrain(world);
     WorldUpdater.tickTreeAging(world);
+    WorldUpdater.tickTreeSustain(world);
+    WorldUpdater.tickFlowerDecay(world);
     WorldUpdater.tickBlockDecay(world);
   }
 }

--- a/src/domains/ui/input-handler.ts
+++ b/src/domains/ui/input-handler.ts
@@ -1,4 +1,4 @@
-import { CELL_PX, GRID_SIZE, OBSTACLE_EMOJIS } from '../../core/constants';
+import { CELL_PX, GRID_SIZE, OBSTACLE_EMOJIS, OBSTACLE_CATEGORY } from '../../core/constants';
 import { key, log, uuid } from '../../core/utils';
 import type { World } from '../world';
 import type { Camera } from '../rendering/camera';
@@ -64,7 +64,8 @@ export class InputHandler {
           !world.agentsByCell.has(k)
         ) {
           const emoji = OBSTACLE_EMOJIS[Math.floor(Math.random() * OBSTACLE_EMOJIS.length)];
-          world.obstacles.set(k, { id: uuid(), x, y, emoji, hp: 12, maxHp: 12 });
+          const category = OBSTACLE_CATEGORY[emoji] ?? 'rock';
+          world.obstacles.set(k, { id: uuid(), x, y, emoji, category, hp: 12, maxHp: 12 });
           log(world, 'build', `Obstacle @${x},${y} (user)`, null, { x, y });
         }
       } else if (world.paintMode === 'erase') {

--- a/src/domains/world/food-field.ts
+++ b/src/domains/world/food-field.ts
@@ -40,6 +40,7 @@ export class FoodField {
       if (grid.flagCells.has(k)) return true;
       if (grid.waterBlocks.has(k)) return true;
       if (grid.treeBlocks.has(k)) return true;
+      if (grid.cactusBlocks.has(k)) return true;
       return false;
     };
     const qx = new Int16Array(N);

--- a/src/domains/world/grid.ts
+++ b/src/domains/world/grid.ts
@@ -1,6 +1,6 @@
 import { GRID_SIZE } from '../../core/constants';
 import { key } from '../../core/utils';
-import type { IFoodBlock, IFarm, IObstacle, IFlag, IWaterBlock, ITreeBlock, ISeedling, ILootBag, IPoopBlock, IEgg, ISaltWaterBlock } from './types';
+import type { IFoodBlock, IFarm, IObstacle, IFlag, IWaterBlock, ITreeBlock, ISeedling, ILootBag, IPoopBlock, IEgg, ISaltWaterBlock, IMedicineBlock, IFlowerBlock, ICactusBlock } from './types';
 
 export class Grid {
   size: number = GRID_SIZE;
@@ -17,6 +17,9 @@ export class Grid {
   readonly poopBlocks: Map<string, IPoopBlock> = new Map();
   readonly eggs: Map<string, IEgg> = new Map();
   readonly saltWaterBlocks: Map<string, ISaltWaterBlock> = new Map();
+  readonly medicineBlocks: Map<string, IMedicineBlock> = new Map();
+  readonly flowerBlocks: Map<string, IFlowerBlock> = new Map();
+  readonly cactusBlocks: Map<string, ICactusBlock> = new Map();
 
   isBlocked(x: number, y: number, ignoreId: string | null = null): boolean {
     if (x < 0 || y < 0 || x >= this.size || y >= this.size) return true;
@@ -26,6 +29,7 @@ export class Grid {
     if (this.flagCells.has(k)) return true;
     if (this.waterBlocks.has(k)) return true;
     if (this.treeBlocks.has(k)) return true;
+    if (this.cactusBlocks.has(k)) return true;
     if (this.saltWaterBlocks.has(k)) return true;
     const occ = this.agentsByCell.get(k);
     if (occ && occ !== ignoreId) return true;
@@ -41,6 +45,7 @@ export class Grid {
     if (this.flagCells.has(k)) return true;
     if (this.waterBlocks.has(k)) return true;
     if (this.treeBlocks.has(k)) return true;
+    if (this.cactusBlocks.has(k)) return true;
     if (this.saltWaterBlocks.has(k)) return true;
     return false;
   }
@@ -60,7 +65,10 @@ export class Grid {
       this.poopBlocks.has(k) ||
       this.agentsByCell.has(k) ||
       this.eggs.has(k) ||
-      this.saltWaterBlocks.has(k)
+      this.saltWaterBlocks.has(k) ||
+      this.medicineBlocks.has(k) ||
+      this.flowerBlocks.has(k) ||
+      this.cactusBlocks.has(k)
     );
   }
 
@@ -87,5 +95,8 @@ export class Grid {
     this.poopBlocks.clear();
     this.eggs.clear();
     this.saltWaterBlocks.clear();
+    this.medicineBlocks.clear();
+    this.flowerBlocks.clear();
+    this.cactusBlocks.clear();
   }
 }

--- a/src/domains/world/types.ts
+++ b/src/domains/world/types.ts
@@ -2,6 +2,10 @@
 
 export type FoodQuality = 'hq' | 'lq';
 
+export type TreeVariant = 'tropical' | 'evergreen' | 'regular';
+
+export type ObstacleCategory = 'mountain' | 'rock' | 'wood';
+
 export interface IFoodBlock {
   id: string;
   x: number;
@@ -25,6 +29,7 @@ export interface IObstacle {
   x: number;
   y: number;
   emoji: string;
+  category: ObstacleCategory;
   hp: number;
   maxHp: number;
   size?: '2x2';
@@ -69,6 +74,7 @@ export interface ITreeBlock {
   x: number;
   y: number;
   emoji: string;
+  variant: TreeVariant;
   units: number;
   maxUnits: number;
   ageTotalMs: number;
@@ -79,9 +85,32 @@ export interface ISeedling {
   id: string;
   x: number;
   y: number;
+  variant: TreeVariant;
   plantedAtTick: number;
   growthDurationMs: number;
   growthElapsedMs: number;
+}
+
+export interface IMedicineBlock {
+  id: string;
+  x: number;
+  y: number;
+}
+
+export interface IFlowerBlock {
+  id: string;
+  x: number;
+  y: number;
+  emoji: string;
+  lifespanMs: number;
+}
+
+export interface ICactusBlock {
+  id: string;
+  x: number;
+  y: number;
+  units: number;
+  maxUnits: number;
 }
 
 export interface ICloud {

--- a/src/domains/world/water-field.ts
+++ b/src/domains/world/water-field.ts
@@ -39,6 +39,7 @@ export class WaterField {
       if (grid.farms.has(k)) return true;
       if (grid.flagCells.has(k)) return true;
       if (grid.treeBlocks.has(k)) return true;
+      if (grid.cactusBlocks.has(k)) return true;
       // Water blocks themselves are seeds, not obstacles for this field
       return false;
     };

--- a/src/domains/world/world-generator.ts
+++ b/src/domains/world/world-generator.ts
@@ -1,4 +1,4 @@
-import { GRID_SIZE, OBSTACLE_EMOJIS } from '../../core/constants';
+import { GRID_SIZE, OBSTACLE_EMOJIS, OBSTACLE_CATEGORY } from '../../core/constants';
 import { key, rndi, uuid } from '../../core/utils';
 import { TUNE } from '../../core/tuning';
 import type { World } from './world';
@@ -42,6 +42,7 @@ export class WorldGenerator {
     const obstacleCount = rndi(30, 50);
     for (let i = 0; i < obstacleCount; i++) {
       const emoji = OBSTACLE_EMOJIS[Math.floor(Math.random() * OBSTACLE_EMOJIS.length)];
+      const category = OBSTACLE_CATEGORY[emoji] ?? 'rock';
       if (Math.random() < 0.4) {
         let placed = false;
         for (let attempt = 0; attempt < 50; attempt++) {
@@ -51,7 +52,7 @@ export class WorldGenerator {
               !world.grid.isCellOccupied(x + 1, y) &&
               !world.grid.isCellOccupied(x, y + 1) &&
               !world.grid.isCellOccupied(x + 1, y + 1)) {
-            const obs = { id: uuid(), x, y, emoji, hp: 24, maxHp: 24, size: '2x2' as const };
+            const obs = { id: uuid(), x, y, emoji, category, hp: 24, maxHp: 24, size: '2x2' as const };
             world.obstacles.set(key(x, y),         obs);
             world.obstacles.set(key(x + 1, y),     obs);
             world.obstacles.set(key(x, y + 1),     obs);
@@ -62,11 +63,11 @@ export class WorldGenerator {
         }
         if (!placed) {
           const { x, y } = world.grid.randomFreeCell();
-          world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji, hp: 12, maxHp: 12 });
+          world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji, category, hp: 12, maxHp: 12 });
         }
       } else {
         const { x, y } = world.grid.randomFreeCell();
-        world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji, hp: 12, maxHp: 12 });
+        world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji, category, hp: 12, maxHp: 12 });
       }
     }
   }
@@ -104,7 +105,8 @@ export class WorldGenerator {
     }
 
     // Place obstacles on boundary cells (cells adjacent to a different region)
-    const emoji = OBSTACLE_EMOJIS[Math.floor(Math.random() * OBSTACLE_EMOJIS.length)];
+    const barrierEmoji = OBSTACLE_EMOJIS[Math.floor(Math.random() * OBSTACLE_EMOJIS.length)];
+    const barrierCategory = OBSTACLE_CATEGORY[barrierEmoji] ?? 'rock';
     for (let y = 1; y < GRID_SIZE - 1; y++) {
       for (let x = 1; x < GRID_SIZE - 1; x++) {
         const r = region[y * GRID_SIZE + x];
@@ -117,7 +119,7 @@ export class WorldGenerator {
         // ~40% fill — leave gaps for cross-region pathfinding
         if (Math.random() > 0.4) continue;
         if (world.grid.isCellOccupied(x, y)) continue;
-        world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji, hp: 12, maxHp: 12 });
+        world.obstacles.set(key(x, y), { id: uuid(), x, y, emoji: barrierEmoji, category: barrierCategory, hp: 12, maxHp: 12 });
       }
     }
   }

--- a/src/domains/world/world.ts
+++ b/src/domains/world/world.ts
@@ -87,4 +87,7 @@ export class World {
   get poopBlocks() { return this.grid.poopBlocks; }
   get eggs() { return this.grid.eggs; }
   get saltWaterBlocks() { return this.grid.saltWaterBlocks; }
+  get medicineBlocks() { return this.grid.medicineBlocks; }
+  get flowerBlocks() { return this.grid.flowerBlocks; }
+  get cactusBlocks() { return this.grid.cactusBlocks; }
 }


### PR DESCRIPTION
## Summary

- **Tree variant system** — tropical (🌴), evergreen (🌲), and regular (🌳) trees with distinct sustain rules (fresh water, saltwater, or mountain proximity), density caps on tropical/regular, and variant-specific fruit (🥥 coconuts, random tree fruits, nothing for evergreens)
- **New plant types** — medicine (🌿, passable, cures disease when harvested by diseased agents), flowers (🌹🌺🌷🌻🪻, passable, decorative with lifespan fade), cactus (🌵, blocks movement, yields water in arid zones far from any water)
- **Tree/seedling dehydration** — trees lose units and die without sustain; seedlings reverse their growth progress and die without water instead of just slowing down
- **Farm crops** now always produce 🌾; obstacle categories (mountain/rock/wood) added for terrain-aware sustain checks; emoji cleanup (🌿/🍎/🍑 removed from food arrays)
- **Backwards-compatible persistence** — v4.2 saves load cleanly via `??` defaults throughout; version bumped to v4.3

## Test plan

- [ ] New world generates all three tree variants; trees without water/mountain sustain visually desaturate and eventually die
- [ ] Tropical trees spawn near saltwater; evergreen trees survive near mountains without freshwater
- [ ] Density caps work: tropical clusters stay ≤2 and regular ≤3 in any 3×3 area
- [ ] Farms produce 🌾 crops; regular trees drop fruit (🍎🍐 etc.), tropical drops 🥥 (capped at 3 nearby), evergreen drops nothing
- [ ] Medicine (🌿) spawns near mountain obstacles; diseased agents seek and harvest it to cure themselves
- [ ] Flowers spawn near water and fade out at end of lifespan
- [ ] Cactus (🌵) spawns in dry areas far from water; agents can harvest water from it; blocks pathfinding
- [ ] Load a v4.2 save — trees/seedlings get correct variant inferred from emoji, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)